### PR TITLE
Implement `Copy` for `Program`

### DIFF
--- a/rs-lib/src/types.rs
+++ b/rs-lib/src/types.rs
@@ -79,6 +79,7 @@ implement_root_node!(Script<'a>);
 implement_root_node!(&Script<'a>);
 
 /// A Module or Script node.
+#[derive(Clone, Copy)]
 pub enum Program<'a> {
   Module(&'a Module<'a>),
   Script(&'a Script<'a>),


### PR DESCRIPTION
`Program` enum's variants are immutable references so it's cheap to copy. I think deriving `Copy` would be helpful for refactoring https://github.com/denoland/deno_lint/pull/604.