### PR TITLE
feat: Implement `Serialize` trait for each `Node`

### DIFF
--- a/generation/generate/generate.ts
+++ b/generation/generate/generate.ts
@@ -435,6 +435,7 @@ export function generate(analysisResult: AnalysisResult) {
                 }
                 writer.writeLine("#[serde(skip)]");
                 writer.writeLine(`pub inner: &'a swc_ast::${struct.name},`);
+                writer.writeLine(`pub span: Span,`);
 
                 for (const field of structFields) {
                     writeDocs(field.docs);
@@ -656,6 +657,7 @@ export function generate(analysisResult: AnalysisResult) {
                 writer.write(`let node = bump.alloc(${struct.name} {`).newLine();
                 writer.indent(() => {
                     writer.write("inner,").newLine();
+                    writer.write("span: inner.span(),").newLine();
                     if (struct.parents.length > 0) {
                         if (struct.parents.length === 1) {
                             writer.write(`parent: parent.expect::<${struct.parents[0].name}>()`);

--- a/generation/generate/generate_serialize.ts
+++ b/generation/generate/generate_serialize.ts
@@ -1,0 +1,86 @@
+import { AnalysisResult, StructDefinition } from "../analyze/analysis_types.ts";
+import { writeHeader, getIsForImpl, writeType } from "../utils/generationUtils.ts";
+import { Writer } from "./writer.ts";
+
+export function generateSerialize(analysisResult: AnalysisResult): string {
+    const writer = new Writer();
+
+    writeHeader(writer);
+    writeUseDeclarations();
+
+    for (const struct of analysisResult.structs) {
+        writer.newLine();
+        writeSerializableStruct(struct);
+        writer.newLine();
+        writeFromImpl(struct);
+    }
+
+    return writer.toString();
+
+    function writeUseDeclarations() {
+        writer.writeLine("use std::marker::PhantomData;");
+        writer.writeLine("use serde::Serialize;");
+        writer.writeLine("use swc_common::{Span, Spanned};");
+        writer.writeLine("use crate::generated::*;");
+    }
+
+    function writeSerializableStruct(struct: StructDefinition) {
+        const implFields = struct.fields.filter(f => getIsForImpl(analysisResult, f.type));
+        const structFields = struct.fields.filter(f => !getIsForImpl(analysisResult, f.type) && f.name !== "span");
+
+        writer.writeLine("#[derive(Serialize)]");
+        writer.writeLine(`#[serde(rename = "${struct.name}", rename_all = "camelCase", tag = "nodeKind")]`);
+        writer.writeLine(`pub struct Serializable${struct.name}<'a> {`);
+        writer.indent(() => {
+            writer.writeLine(`span: Span,`);
+
+            for (const field of implFields) {
+                writer.write(`${field.name}: `);
+                writeType(writer, analysisResult, field.type, false);
+                writer.write(",").newLine();
+            }
+
+            for (const field of structFields) {
+                writer.write(`${field.name}: `);
+                writeType(writer, analysisResult, field.type, true);
+                writer.write(",").newLine();
+            }
+
+            writer.newLine();
+            writer.writeLine("#[doc(hidden)]");
+            writer.writeLine("#[serde(skip)]");
+            writer.writeLine(`_phantom: PhantomData<&'a ()>,`);
+        });
+        writer.writeLine("}");
+    }
+
+    function writeFromImpl(struct: StructDefinition) {
+        const implFields = struct.fields.filter(f => getIsForImpl(analysisResult, f.type));
+        const structFields = struct.fields.filter(f => !getIsForImpl(analysisResult, f.type) && f.name !== "span");
+
+        writer.writeLine(`impl<'a> From<${struct.name}<'a>> for Serializable${struct.name}<'a> {`);
+        writer.indent(() => {
+            writer.writeLine(`fn from(orig: ${struct.name}<'a>) -> Self {`);
+            writer.indent(() => {
+                writer.writeLine("Self {");
+                writer.indent(() => {
+                    writer.writeLine(`span: orig.span(),`);
+
+                    for (const field of implFields) {
+                        writer.writeLine(`${field.name}: orig.${field.name}().clone(),`);
+                    }
+
+                    for (const field of structFields) {
+                        writer.writeLine(`${field.name}: orig.${field.name},`);
+                    }
+
+                    writer.writeLine(`_phantom: PhantomData,`);
+                });
+                writer.writeLine("}");
+            });
+            writer.writeLine("}");
+        });
+        writer.writeLine("}");
+    }
+}
+

--- a/generation/main.ts
+++ b/generation/main.ts
@@ -1,7 +1,10 @@
 import { analyze } from "./analyze/analyze.ts";
 import { generate } from "./generate/generate.ts";
+import { generateSerialize } from "./generate/generate_serialize.ts";
 
 const analysisResult = analyze();
 const generatedCode = generate(analysisResult);
+const generatedSerializeCode = generateSerialize(analysisResult);
 
 Deno.writeTextFileSync("./rs-lib/src/generated.rs", generatedCode);
+Deno.writeTextFileSync("./rs-lib/src/generated_serialize.rs", generatedSerializeCode);

--- a/generation/utils/generationUtils.ts
+++ b/generation/utils/generationUtils.ts
@@ -1,0 +1,80 @@
+import {
+    AnalysisResult,
+    TypeDefinition,
+    PrimitiveTypeDefinition,
+    TypeReferenceDefinition,
+} from "../analyze/analysis_types.ts";
+import { Writer } from "../generate/writer.ts";
+
+export function writeHeader(writer: Writer) {
+    writer.writeLine("// This code is code generated.");
+    writer.writeLine("// Run `./scripts/generate.sh` from the root directory to regenerate it.");
+}
+
+export function getIsForImpl(analysisResult: AnalysisResult, type: TypeDefinition): boolean {
+    if (type.kind === "primitive") {
+        return true;
+    }
+    if (type.name === "Option" || type.name === "Vec") {
+        return getIsForImpl(analysisResult, type.generic_args[0]);
+    }
+    if (type.path[0] === "swc_ecma_ast") {
+        return analysisResult.enums.some(s => s.isPlain && s.name === type.path[1]);
+    }
+    return true;
+}
+
+export function writeType(writer: Writer, analysisResult: AnalysisResult, type: TypeDefinition, writeStructReference: boolean): void {
+    switch (type.kind) {
+        case "primitive":
+            writePrimitive(type);
+            break;
+        case "reference":
+            writeReference(type);
+            break;
+        default:
+            const _assertNever: never = type;
+            throw new Error("Not handled type.");
+    }
+
+    function writePrimitive(type: PrimitiveTypeDefinition) {
+        writer.write(type.text);
+    }
+
+    function writeReference(type: TypeReferenceDefinition) {
+        const path = type.path.join("::").replace(/^swc_ecma_ast::/, "");
+        if (analysisResult.enums.some(e => !e.isPlain && e.name === type.name) || analysisResult.structs.some(s => s.name === type.name)) {
+            if (type.generic_args.length > 0) {
+                throw new Error("Unhandled.");
+            }
+            if (analysisResult.structs.some(s => s.name === type.name) && writeStructReference) {
+                writer.write("&'a ");
+            }
+            writer.write(path);
+            writer.write("<'a>");
+        } else if (type.generic_args.length > 0) {
+            writer.write(path);
+            writer.write("<");
+            writer.write(type.generic_args.map(type => writeType(writer, analysisResult, type, writeStructReference)).join(", "));
+            writer.write(">");
+        } else {
+            writer.write(path);
+        }
+    }
+}
+
+export function getIsReferenceType(analysisResult: AnalysisResult, type: TypeDefinition): boolean {
+    if (type.kind === "primitive") {
+        return false;
+    }
+    if (type.name === "Option") {
+        return getIsReferenceType(analysisResult, type.generic_args[0]);
+    }
+
+    const isSwcPlainEnumType = type != null && type.kind === "reference" && analysisResult.enums.some(e => e.isPlain && e.name === type.name);
+    if (isSwcPlainEnumType) {
+        return false;
+    }
+    return true;
+}
+

--- a/rs-lib/.rustfmt.toml
+++ b/rs-lib/.rustfmt.toml
@@ -1,0 +1,2 @@
+tab_spaces = 2
+edition = "2018"

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+serialize = ["serde"]
+
 [dependencies]
 swc_common = "0.10.12"
 swc_atoms = "0.2.5"
@@ -15,7 +19,7 @@ swc_ecmascript = { version = "0.25.0", features = ["parser"] }
 num-bigint = "0.2"
 bumpalo = "3.4.0"
 fnv = "1.0.3"
-serde = { version = "1.0.124", features = ["derive"] }
+serde = { version = "1.0.124", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.64"

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -23,3 +23,4 @@ serde = { version = "1.0.124", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.64"
+pretty_assertions = "0.7.1"

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -15,3 +15,4 @@ swc_ecmascript = { version = "0.25.0", features = ["parser"] }
 num-bigint = "0.2"
 bumpalo = "3.4.0"
 fnv = "1.0.3"
+serde = { version = "1.0.124", features = ["derive"] }

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -16,3 +16,6 @@ num-bigint = "0.2"
 bumpalo = "3.4.0"
 fnv = "1.0.3"
 serde = { version = "1.0.124", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0.64"

--- a/rs-lib/src/generated.rs
+++ b/rs-lib/src/generated.rs
@@ -1,13 +1,15 @@
 // This code is code generated.
-// Run `deno run -A generation/main.ts` from the root directory to regenerate it.
+// Run `./scripts/generate.sh` from the root directory to regenerate it.
 use std::mem::{self, MaybeUninit};
 use bumpalo::Bump;
-use serde::Serialize;
 use swc_common::{Span, Spanned};
 pub use swc_ecmascript::ast::{self as swc_ast, Accessibility, AssignOp, BinaryOp, EsVersion, MethodKind, StrKind, TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp, UnaryOp, UpdateOp, VarDeclKind};
 use crate::comments::*;
 use crate::tokens::*;
 use crate::types::*;
+
+#[cfg(feature = "serialize")]
+use serde::Serialize;
 
 thread_local! {
   static LOCAL_BUMP_ALLOCATOR: std::cell::RefCell<Bump> = std::cell::RefCell::new(Bump::new());
@@ -1401,8 +1403,9 @@ impl std::fmt::Display for NodeKind {
 }
 
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum BlockStmtOrExpr<'a> {
   BlockStmt(&'a BlockStmt<'a>),
   Expr(Expr<'a>),
@@ -1491,8 +1494,9 @@ fn get_view_for_block_stmt_or_expr<'a>(inner: &'a swc_ast::BlockStmtOrExpr, pare
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ClassMember<'a> {
   Constructor(&'a Constructor<'a>),
   /// `es2015`
@@ -1628,8 +1632,9 @@ fn get_view_for_class_member<'a>(inner: &'a swc_ast::ClassMember, parent: Node<'
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum Decl<'a> {
   Class(&'a ClassDecl<'a>),
   Fn(&'a FnDecl<'a>),
@@ -1763,8 +1768,9 @@ fn get_view_for_decl<'a>(inner: &'a swc_ast::Decl, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum DefaultDecl<'a> {
   Class(&'a ClassExpr<'a>),
   Fn(&'a FnExpr<'a>),
@@ -1862,8 +1868,9 @@ fn get_view_for_default_decl<'a>(inner: &'a swc_ast::DefaultDecl, parent: Node<'
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ExportSpecifier<'a> {
   Namespace(&'a ExportNamespaceSpecifier<'a>),
   Default(&'a ExportDefaultSpecifier<'a>),
@@ -1961,8 +1968,9 @@ fn get_view_for_export_specifier<'a>(inner: &'a swc_ast::ExportSpecifier, parent
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum Expr<'a> {
   This(&'a ThisExpr<'a>),
   Array(&'a ArrayLit<'a>),
@@ -2355,8 +2363,9 @@ fn get_view_for_expr<'a>(inner: &'a swc_ast::Expr, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ExprOrSuper<'a> {
   Super(&'a Super<'a>),
   Expr(Expr<'a>),
@@ -2445,8 +2454,9 @@ fn get_view_for_expr_or_super<'a>(inner: &'a swc_ast::ExprOrSuper, parent: Node<
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ImportSpecifier<'a> {
   Named(&'a ImportNamedSpecifier<'a>),
   Default(&'a ImportDefaultSpecifier<'a>),
@@ -2544,8 +2554,9 @@ fn get_view_for_import_specifier<'a>(inner: &'a swc_ast::ImportSpecifier, parent
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXAttrName<'a> {
   Ident(&'a Ident<'a>),
   JSXNamespacedName(&'a JSXNamespacedName<'a>),
@@ -2634,8 +2645,9 @@ fn get_view_for_jsxattr_name<'a>(inner: &'a swc_ast::JSXAttrName, parent: Node<'
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXAttrOrSpread<'a> {
   JSXAttr(&'a JSXAttr<'a>),
   SpreadElement(&'a SpreadElement<'a>),
@@ -2724,8 +2736,9 @@ fn get_view_for_jsxattr_or_spread<'a>(inner: &'a swc_ast::JSXAttrOrSpread, paren
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXAttrValue<'a> {
   Lit(Lit<'a>),
   JSXExprContainer(&'a JSXExprContainer<'a>),
@@ -2832,8 +2845,9 @@ fn get_view_for_jsxattr_value<'a>(inner: &'a swc_ast::JSXAttrValue, parent: Node
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXElementChild<'a> {
   JSXText(&'a JSXText<'a>),
   JSXExprContainer(&'a JSXExprContainer<'a>),
@@ -2949,8 +2963,9 @@ fn get_view_for_jsxelement_child<'a>(inner: &'a swc_ast::JSXElementChild, parent
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXElementName<'a> {
   Ident(&'a Ident<'a>),
   JSXMemberExpr(&'a JSXMemberExpr<'a>),
@@ -3048,8 +3063,9 @@ fn get_view_for_jsxelement_name<'a>(inner: &'a swc_ast::JSXElementName, parent: 
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXExpr<'a> {
   JSXEmptyExpr(&'a JSXEmptyExpr<'a>),
   Expr(Expr<'a>),
@@ -3139,8 +3155,9 @@ fn get_view_for_jsxexpr<'a>(inner: &'a swc_ast::JSXExpr, parent: Node<'a>, bump:
 }
 
 /// Used for `obj` property of `JSXMemberExpr`.
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXObject<'a> {
   JSXMemberExpr(&'a JSXMemberExpr<'a>),
   Ident(&'a Ident<'a>),
@@ -3229,8 +3246,9 @@ fn get_view_for_jsxobject<'a>(inner: &'a swc_ast::JSXObject, parent: Node<'a>, b
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum Lit<'a> {
   Str(&'a Str<'a>),
   Bool(&'a Bool<'a>),
@@ -3364,8 +3382,9 @@ fn get_view_for_lit<'a>(inner: &'a swc_ast::Lit, parent: Node<'a>, bump: &'a Bum
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ModuleDecl<'a> {
   Import(&'a ImportDecl<'a>),
   ExportDecl(&'a ExportDecl<'a>),
@@ -3517,8 +3536,9 @@ fn get_view_for_module_decl<'a>(inner: &'a swc_ast::ModuleDecl, parent: Node<'a>
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ModuleItem<'a> {
   ModuleDecl(ModuleDecl<'a>),
   Stmt(Stmt<'a>),
@@ -3607,8 +3627,9 @@ fn get_view_for_module_item<'a>(inner: &'a swc_ast::ModuleItem, parent: Node<'a>
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ObjectPatProp<'a> {
   KeyValue(&'a KeyValuePatProp<'a>),
   Assign(&'a AssignPatProp<'a>),
@@ -3706,8 +3727,9 @@ fn get_view_for_object_pat_prop<'a>(inner: &'a swc_ast::ObjectPatProp, parent: N
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum ParamOrTsParamProp<'a> {
   TsParamProp(&'a TsParamProp<'a>),
   Param(&'a Param<'a>),
@@ -3796,8 +3818,9 @@ fn get_view_for_param_or_ts_param_prop<'a>(inner: &'a swc_ast::ParamOrTsParamPro
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum Pat<'a> {
   Ident(&'a BindingIdent<'a>),
   Array(&'a ArrayPat<'a>),
@@ -3932,8 +3955,9 @@ fn get_view_for_pat<'a>(inner: &'a swc_ast::Pat, parent: Node<'a>, bump: &'a Bum
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum PatOrExpr<'a> {
   Expr(Expr<'a>),
   Pat(Pat<'a>),
@@ -4022,8 +4046,9 @@ fn get_view_for_pat_or_expr<'a>(inner: &'a swc_ast::PatOrExpr, parent: Node<'a>,
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum Prop<'a> {
   /// `a` in `{ a, }`
   Shorthand(&'a Ident<'a>),
@@ -4151,8 +4176,9 @@ fn get_view_for_prop<'a>(inner: &'a swc_ast::Prop, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum PropName<'a> {
   Ident(&'a Ident<'a>),
   /// String literal.
@@ -4270,8 +4296,9 @@ fn get_view_for_prop_name<'a>(inner: &'a swc_ast::PropName, parent: Node<'a>, bu
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum PropOrSpread<'a> {
   /// Spread properties, e.g., `{a: 1, ...obj, b: 2}`.
   Spread(&'a SpreadElement<'a>),
@@ -4361,8 +4388,9 @@ fn get_view_for_prop_or_spread<'a>(inner: &'a swc_ast::PropOrSpread, parent: Nod
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum Stmt<'a> {
   Block(&'a BlockStmt<'a>),
   Empty(&'a EmptyStmt<'a>),
@@ -4605,8 +4633,9 @@ fn get_view_for_stmt<'a>(inner: &'a swc_ast::Stmt, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsEntityName<'a> {
   TsQualifiedName(&'a TsQualifiedName<'a>),
   Ident(&'a Ident<'a>),
@@ -4697,8 +4726,9 @@ fn get_view_for_ts_entity_name<'a>(inner: &'a swc_ast::TsEntityName, parent: Nod
 
 ///
 /// - Invalid: [Ident] with empty symbol.
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsEnumMemberId<'a> {
   Ident(&'a Ident<'a>),
   Str(&'a Str<'a>),
@@ -4787,8 +4817,9 @@ fn get_view_for_ts_enum_member_id<'a>(inner: &'a swc_ast::TsEnumMemberId, parent
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsFnOrConstructorType<'a> {
   TsFnType(&'a TsFnType<'a>),
   TsConstructorType(&'a TsConstructorType<'a>),
@@ -4877,8 +4908,9 @@ fn get_view_for_ts_fn_or_constructor_type<'a>(inner: &'a swc_ast::TsFnOrConstruc
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsFnParam<'a> {
   Ident(&'a BindingIdent<'a>),
   Array(&'a ArrayPat<'a>),
@@ -4985,8 +5017,9 @@ fn get_view_for_ts_fn_param<'a>(inner: &'a swc_ast::TsFnParam, parent: Node<'a>,
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsLit<'a> {
   Number(&'a Number<'a>),
   Str(&'a Str<'a>),
@@ -5102,8 +5135,9 @@ fn get_view_for_ts_lit<'a>(inner: &'a swc_ast::TsLit, parent: Node<'a>, bump: &'
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsModuleName<'a> {
   Ident(&'a Ident<'a>),
   Str(&'a Str<'a>),
@@ -5192,8 +5226,9 @@ fn get_view_for_ts_module_name<'a>(inner: &'a swc_ast::TsModuleName, parent: Nod
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsModuleRef<'a> {
   TsEntityName(TsEntityName<'a>),
   TsExternalModuleRef(&'a TsExternalModuleRef<'a>),
@@ -5284,8 +5319,9 @@ fn get_view_for_ts_module_ref<'a>(inner: &'a swc_ast::TsModuleRef, parent: Node<
 
 /// `namespace A.B { }` is a namespace named `A` with another TsNamespaceDecl as
 /// its body.
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsNamespaceBody<'a> {
   TsModuleBlock(&'a TsModuleBlock<'a>),
   TsNamespaceDecl(&'a TsNamespaceDecl<'a>),
@@ -5374,8 +5410,9 @@ fn get_view_for_ts_namespace_body<'a>(inner: &'a swc_ast::TsNamespaceBody, paren
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsParamPropParam<'a> {
   Ident(&'a BindingIdent<'a>),
   Assign(&'a AssignPat<'a>),
@@ -5464,8 +5501,9 @@ fn get_view_for_ts_param_prop_param<'a>(inner: &'a swc_ast::TsParamPropParam, pa
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsThisTypeOrIdent<'a> {
   TsThisType(&'a TsThisType<'a>),
   Ident(&'a Ident<'a>),
@@ -5554,8 +5592,9 @@ fn get_view_for_ts_this_type_or_ident<'a>(inner: &'a swc_ast::TsThisTypeOrIdent,
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsType<'a> {
   TsKeywordType(&'a TsKeywordType<'a>),
   TsThisType(&'a TsThisType<'a>),
@@ -5806,8 +5845,9 @@ fn get_view_for_ts_type<'a>(inner: &'a swc_ast::TsType, parent: Node<'a>, bump: 
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsTypeElement<'a> {
   TsCallSignatureDecl(&'a TsCallSignatureDecl<'a>),
   TsConstructSignatureDecl(&'a TsConstructSignatureDecl<'a>),
@@ -5923,8 +5963,9 @@ fn get_view_for_ts_type_element<'a>(inner: &'a swc_ast::TsTypeElement, parent: N
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsTypeQueryExpr<'a> {
   TsEntityName(TsEntityName<'a>),
   Import(&'a TsImportType<'a>),
@@ -6013,8 +6054,9 @@ fn get_view_for_ts_type_query_expr<'a>(inner: &'a swc_ast::TsTypeQueryExpr, pare
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TsUnionOrIntersectionType<'a> {
   TsUnionType(&'a TsUnionType<'a>),
   TsIntersectionType(&'a TsIntersectionType<'a>),
@@ -6103,8 +6145,9 @@ fn get_view_for_ts_union_or_intersection_type<'a>(inner: &'a swc_ast::TsUnionOrI
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum VarDeclOrExpr<'a> {
   VarDecl(&'a VarDecl<'a>),
   Expr(Expr<'a>),
@@ -6193,8 +6236,9 @@ fn get_view_for_var_decl_or_expr<'a>(inner: &'a swc_ast::VarDeclOrExpr, parent: 
   }
 }
 
-#[derive(Copy, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum VarDeclOrPat<'a> {
   VarDecl(&'a VarDecl<'a>),
   Pat(Pat<'a>),
@@ -6284,14 +6328,12 @@ fn get_view_for_var_decl_or_pat<'a>(inner: &'a swc_ast::VarDeclOrPat, parent: No
 }
 
 /// Array literal.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableArrayLit"))]
 pub struct ArrayLit<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ArrayLit,
-  pub span: Span,
   pub elems: Vec<Option<&'a ExprOrSpread<'a>>>,
 }
 
@@ -6348,7 +6390,6 @@ impl<'a> CastableNode<'a> for ArrayLit<'a> {
 fn get_view_for_array_lit<'a>(inner: &'a swc_ast::ArrayLit, parent: Node<'a>, bump: &'a Bump) -> &'a ArrayLit<'a> {
   let node = bump.alloc(ArrayLit {
     inner,
-    span: inner.span(),
     parent,
     elems: Vec::with_capacity(inner.elems.len()),
   });
@@ -6360,18 +6401,21 @@ fn get_view_for_array_lit<'a>(inner: &'a swc_ast::ArrayLit, parent: Node<'a>, bu
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableArrayPat"))]
 pub struct ArrayPat<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ArrayPat,
-  pub span: Span,
   pub elems: Vec<Option<Pat<'a>>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
+}
+
+impl<'a> ArrayPat<'a> {
   /// Only in an ambient context
-  pub optional: bool,
+  pub fn optional(&self) -> bool {
+    self.inner.optional
+  }
 }
 
 impl<'a> Spanned for ArrayPat<'a> {
@@ -6430,11 +6474,9 @@ impl<'a> CastableNode<'a> for ArrayPat<'a> {
 fn get_view_for_array_pat<'a>(inner: &'a swc_ast::ArrayPat, parent: Node<'a>, bump: &'a Bump) -> &'a ArrayPat<'a> {
   let node = bump.alloc(ArrayPat {
     inner,
-    span: inner.span(),
     parent,
     elems: Vec::with_capacity(inner.elems.len()),
     type_ann: None,
-    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.elems.extend(inner.elems.iter().map(|value| match value {
@@ -6448,20 +6490,26 @@ fn get_view_for_array_pat<'a>(inner: &'a swc_ast::ArrayPat, parent: Node<'a>, bu
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableArrowExpr"))]
 pub struct ArrowExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ArrowExpr,
-  pub span: Span,
   pub params: Vec<Pat<'a>>,
   pub body: BlockStmtOrExpr<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub return_type: Option<&'a TsTypeAnn<'a>>,
-  pub is_async: bool,
-  pub is_generator: bool,
+}
+
+impl<'a> ArrowExpr<'a> {
+  pub fn is_async(&self) -> bool {
+    self.inner.is_async
+  }
+
+  pub fn is_generator(&self) -> bool {
+    self.inner.is_generator
+  }
 }
 
 impl<'a> Spanned for ArrowExpr<'a> {
@@ -6522,14 +6570,11 @@ impl<'a> CastableNode<'a> for ArrowExpr<'a> {
 fn get_view_for_arrow_expr<'a>(inner: &'a swc_ast::ArrowExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ArrowExpr<'a> {
   let node = bump.alloc(ArrowExpr {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     body: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
     return_type: None,
-    is_async: inner.is_async,
-    is_generator: inner.is_generator,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_pat(value, parent.clone(), bump)));
@@ -6545,17 +6590,20 @@ fn get_view_for_arrow_expr<'a>(inner: &'a swc_ast::ArrowExpr, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableAssignExpr"))]
 pub struct AssignExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::AssignExpr,
-  pub span: Span,
   pub left: PatOrExpr<'a>,
   pub right: Expr<'a>,
-  pub op: AssignOp,
+}
+
+impl<'a> AssignExpr<'a> {
+  pub fn op(&self) -> AssignOp {
+    self.inner.op
+  }
 }
 
 impl<'a> Spanned for AssignExpr<'a> {
@@ -6608,11 +6656,9 @@ impl<'a> CastableNode<'a> for AssignExpr<'a> {
 fn get_view_for_assign_expr<'a>(inner: &'a swc_ast::AssignExpr, parent: Node<'a>, bump: &'a Bump) -> &'a AssignExpr<'a> {
   let node = bump.alloc(AssignExpr {
     inner,
-    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
-    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.left = get_view_for_pat_or_expr(&inner.left, parent.clone(), bump);
@@ -6620,14 +6666,12 @@ fn get_view_for_assign_expr<'a>(inner: &'a swc_ast::AssignExpr, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableAssignPat"))]
 pub struct AssignPat<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::AssignPat,
-  pub span: Span,
   pub left: Pat<'a>,
   pub right: Expr<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -6686,7 +6730,6 @@ impl<'a> CastableNode<'a> for AssignPat<'a> {
 fn get_view_for_assign_pat<'a>(inner: &'a swc_ast::AssignPat, parent: Node<'a>, bump: &'a Bump) -> &'a AssignPat<'a> {
   let node = bump.alloc(AssignPat {
     inner,
-    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -6703,14 +6746,12 @@ fn get_view_for_assign_pat<'a>(inner: &'a swc_ast::AssignPat, parent: Node<'a>, 
 }
 
 /// `{key}` or `{key = value}`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableAssignPatProp"))]
 pub struct AssignPatProp<'a> {
-  #[serde(skip)]
   pub parent: &'a ObjectPat<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::AssignPatProp,
-  pub span: Span,
   pub key: &'a Ident<'a>,
   pub value: Option<Expr<'a>>,
 }
@@ -6767,7 +6808,6 @@ impl<'a> CastableNode<'a> for AssignPatProp<'a> {
 fn get_view_for_assign_pat_prop<'a>(inner: &'a swc_ast::AssignPatProp, parent: Node<'a>, bump: &'a Bump) -> &'a AssignPatProp<'a> {
   let node = bump.alloc(AssignPatProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ObjectPat>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
@@ -6781,14 +6821,12 @@ fn get_view_for_assign_pat_prop<'a>(inner: &'a swc_ast::AssignPatProp, parent: N
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableAssignProp"))]
 pub struct AssignProp<'a> {
-  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::AssignProp,
-  pub span: Span,
   pub key: &'a Ident<'a>,
   pub value: Expr<'a>,
 }
@@ -6843,7 +6881,6 @@ impl<'a> CastableNode<'a> for AssignProp<'a> {
 fn get_view_for_assign_prop<'a>(inner: &'a swc_ast::AssignProp, parent: Node<'a>, bump: &'a Bump) -> &'a AssignProp<'a> {
   let node = bump.alloc(AssignProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: unsafe { MaybeUninit::uninit().assume_init() },
@@ -6854,14 +6891,12 @@ fn get_view_for_assign_prop<'a>(inner: &'a swc_ast::AssignProp, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableAwaitExpr"))]
 pub struct AwaitExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::AwaitExpr,
-  pub span: Span,
   pub arg: Expr<'a>,
 }
 
@@ -6914,7 +6949,6 @@ impl<'a> CastableNode<'a> for AwaitExpr<'a> {
 fn get_view_for_await_expr<'a>(inner: &'a swc_ast::AwaitExpr, parent: Node<'a>, bump: &'a Bump) -> &'a AwaitExpr<'a> {
   let node = bump.alloc(AwaitExpr {
     inner,
-    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -6923,15 +6957,18 @@ fn get_view_for_await_expr<'a>(inner: &'a swc_ast::AwaitExpr, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableBigInt"))]
 pub struct BigInt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::BigInt,
-  pub span: Span,
-  pub value: &'a num_bigint::BigInt,
+}
+
+impl<'a> BigInt<'a> {
+  pub fn value(&self) -> &num_bigint::BigInt {
+    &self.inner.value
+  }
 }
 
 impl<'a> Spanned for BigInt<'a> {
@@ -6981,24 +7018,25 @@ impl<'a> CastableNode<'a> for BigInt<'a> {
 fn get_view_for_big_int<'a>(inner: &'a swc_ast::BigInt, parent: Node<'a>, bump: &'a Bump) -> &'a BigInt<'a> {
   let node = bump.alloc(BigInt {
     inner,
-    span: inner.span(),
     parent,
-    value: &inner.value,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableBinExpr"))]
 pub struct BinExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::BinExpr,
-  pub span: Span,
   pub left: Expr<'a>,
   pub right: Expr<'a>,
-  pub op: BinaryOp,
+}
+
+impl<'a> BinExpr<'a> {
+  pub fn op(&self) -> BinaryOp {
+    self.inner.op
+  }
 }
 
 impl<'a> Spanned for BinExpr<'a> {
@@ -7051,11 +7089,9 @@ impl<'a> CastableNode<'a> for BinExpr<'a> {
 fn get_view_for_bin_expr<'a>(inner: &'a swc_ast::BinExpr, parent: Node<'a>, bump: &'a Bump) -> &'a BinExpr<'a> {
   let node = bump.alloc(BinExpr {
     inner,
-    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
-    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.left = get_view_for_expr(&inner.left, parent.clone(), bump);
@@ -7064,14 +7100,12 @@ fn get_view_for_bin_expr<'a>(inner: &'a swc_ast::BinExpr, parent: Node<'a>, bump
 }
 
 /// Identifer used as a pattern.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableBindingIdent"))]
 pub struct BindingIdent<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::BindingIdent,
-  pub span: Span,
   pub id: &'a Ident<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
 }
@@ -7128,7 +7162,6 @@ impl<'a> CastableNode<'a> for BindingIdent<'a> {
 fn get_view_for_binding_ident<'a>(inner: &'a swc_ast::BindingIdent, parent: Node<'a>, bump: &'a Bump) -> &'a BindingIdent<'a> {
   let node = bump.alloc(BindingIdent {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
@@ -7143,14 +7176,12 @@ fn get_view_for_binding_ident<'a>(inner: &'a swc_ast::BindingIdent, parent: Node
 }
 
 /// Use when only block statements are allowed.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableBlockStmt"))]
 pub struct BlockStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::BlockStmt,
-  pub span: Span,
   pub stmts: Vec<Stmt<'a>>,
 }
 
@@ -7205,7 +7236,6 @@ impl<'a> CastableNode<'a> for BlockStmt<'a> {
 fn get_view_for_block_stmt<'a>(inner: &'a swc_ast::BlockStmt, parent: Node<'a>, bump: &'a Bump) -> &'a BlockStmt<'a> {
   let node = bump.alloc(BlockStmt {
     inner,
-    span: inner.span(),
     parent,
     stmts: Vec::with_capacity(inner.stmts.len()),
   });
@@ -7214,15 +7244,18 @@ fn get_view_for_block_stmt<'a>(inner: &'a swc_ast::BlockStmt, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableBool"))]
 pub struct Bool<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Bool,
-  pub span: Span,
-  pub value: bool,
+}
+
+impl<'a> Bool<'a> {
+  pub fn value(&self) -> bool {
+    self.inner.value
+  }
 }
 
 impl<'a> Spanned for Bool<'a> {
@@ -7272,21 +7305,17 @@ impl<'a> CastableNode<'a> for Bool<'a> {
 fn get_view_for_bool<'a>(inner: &'a swc_ast::Bool, parent: Node<'a>, bump: &'a Bump) -> &'a Bool<'a> {
   let node = bump.alloc(Bool {
     inner,
-    span: inner.span(),
     parent,
-    value: inner.value,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableBreakStmt"))]
 pub struct BreakStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::BreakStmt,
-  pub span: Span,
   pub label: Option<&'a Ident<'a>>,
 }
 
@@ -7341,7 +7370,6 @@ impl<'a> CastableNode<'a> for BreakStmt<'a> {
 fn get_view_for_break_stmt<'a>(inner: &'a swc_ast::BreakStmt, parent: Node<'a>, bump: &'a Bump) -> &'a BreakStmt<'a> {
   let node = bump.alloc(BreakStmt {
     inner,
-    span: inner.span(),
     parent,
     label: None,
   });
@@ -7353,14 +7381,12 @@ fn get_view_for_break_stmt<'a>(inner: &'a swc_ast::BreakStmt, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableCallExpr"))]
 pub struct CallExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::CallExpr,
-  pub span: Span,
   pub callee: ExprOrSuper<'a>,
   pub args: Vec<&'a ExprOrSpread<'a>>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -7421,7 +7447,6 @@ impl<'a> CastableNode<'a> for CallExpr<'a> {
 fn get_view_for_call_expr<'a>(inner: &'a swc_ast::CallExpr, parent: Node<'a>, bump: &'a Bump) -> &'a CallExpr<'a> {
   let node = bump.alloc(CallExpr {
     inner,
-    span: inner.span(),
     parent,
     callee: unsafe { MaybeUninit::uninit().assume_init() },
     args: Vec::with_capacity(inner.args.len()),
@@ -7437,14 +7462,12 @@ fn get_view_for_call_expr<'a>(inner: &'a swc_ast::CallExpr, parent: Node<'a>, bu
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableCatchClause"))]
 pub struct CatchClause<'a> {
-  #[serde(skip)]
   pub parent: &'a TryStmt<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::CatchClause,
-  pub span: Span,
   /// es2019
   ///
   /// The param is null if the catch binding is omitted. E.g., try { foo() }
@@ -7505,7 +7528,6 @@ impl<'a> CastableNode<'a> for CatchClause<'a> {
 fn get_view_for_catch_clause<'a>(inner: &'a swc_ast::CatchClause, parent: Node<'a>, bump: &'a Bump) -> &'a CatchClause<'a> {
   let node = bump.alloc(CatchClause {
     inner,
-    span: inner.span(),
     parent: parent.expect::<TryStmt>(),
     param: None,
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -7519,14 +7541,12 @@ fn get_view_for_catch_clause<'a>(inner: &'a swc_ast::CatchClause, parent: Node<'
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableClass"))]
 pub struct Class<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Class,
-  pub span: Span,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub body: Vec<ClassMember<'a>>,
   pub super_class: Option<Expr<'a>>,
@@ -7534,7 +7554,12 @@ pub struct Class<'a> {
   pub super_type_params: Option<&'a TsTypeParamInstantiation<'a>>,
   /// Typescript extension.
   pub implements: Vec<&'a TsExprWithTypeArgs<'a>>,
-  pub is_abstract: bool,
+}
+
+impl<'a> Class<'a> {
+  pub fn is_abstract(&self) -> bool {
+    self.inner.is_abstract
+  }
 }
 
 impl<'a> Spanned for Class<'a> {
@@ -7603,7 +7628,6 @@ impl<'a> CastableNode<'a> for Class<'a> {
 fn get_view_for_class<'a>(inner: &'a swc_ast::Class, parent: Node<'a>, bump: &'a Bump) -> &'a Class<'a> {
   let node = bump.alloc(Class {
     inner,
-    span: inner.span(),
     parent,
     decorators: Vec::with_capacity(inner.decorators.len()),
     body: Vec::with_capacity(inner.body.len()),
@@ -7611,7 +7635,6 @@ fn get_view_for_class<'a>(inner: &'a swc_ast::Class, parent: Node<'a>, bump: &'a
     type_params: None,
     super_type_params: None,
     implements: Vec::with_capacity(inner.implements.len()),
-    is_abstract: inner.is_abstract,
   });
   let parent: Node<'a> = (&*node).into();
   node.decorators.extend(inner.decorators.iter().map(|value| get_view_for_decorator(value, parent.clone(), bump)));
@@ -7632,17 +7655,20 @@ fn get_view_for_class<'a>(inner: &'a swc_ast::Class, parent: Node<'a>, bump: &'a
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableClassDecl"))]
 pub struct ClassDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ClassDecl,
-  pub span: Span,
   pub ident: &'a Ident<'a>,
   pub class: &'a Class<'a>,
-  pub declare: bool,
+}
+
+impl<'a> ClassDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
 }
 
 impl<'a> Spanned for ClassDecl<'a> {
@@ -7695,11 +7721,9 @@ impl<'a> CastableNode<'a> for ClassDecl<'a> {
 fn get_view_for_class_decl<'a>(inner: &'a swc_ast::ClassDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ClassDecl<'a> {
   let node = bump.alloc(ClassDecl {
     inner,
-    span: inner.span(),
     parent,
     ident: unsafe { MaybeUninit::uninit().assume_init() },
     class: unsafe { MaybeUninit::uninit().assume_init() },
-    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.ident = get_view_for_ident(&inner.ident, parent.clone(), bump);
@@ -7708,14 +7732,12 @@ fn get_view_for_class_decl<'a>(inner: &'a swc_ast::ClassDecl, parent: Node<'a>, 
 }
 
 /// Class expression.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableClassExpr"))]
 pub struct ClassExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ClassExpr,
-  pub span: Span,
   pub ident: Option<&'a Ident<'a>>,
   pub class: &'a Class<'a>,
 }
@@ -7772,7 +7794,6 @@ impl<'a> CastableNode<'a> for ClassExpr<'a> {
 fn get_view_for_class_expr<'a>(inner: &'a swc_ast::ClassExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ClassExpr<'a> {
   let node = bump.alloc(ClassExpr {
     inner,
-    span: inner.span(),
     parent,
     ident: None,
     class: unsafe { MaybeUninit::uninit().assume_init() },
@@ -7786,23 +7807,38 @@ fn get_view_for_class_expr<'a>(inner: &'a swc_ast::ClassExpr, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableClassMethod"))]
 pub struct ClassMethod<'a> {
-  #[serde(skip)]
   pub parent: &'a Class<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ClassMethod,
-  pub span: Span,
   pub key: PropName<'a>,
   pub function: &'a Function<'a>,
-  pub kind: MethodKind,
-  pub is_static: bool,
+}
+
+impl<'a> ClassMethod<'a> {
+  pub fn kind(&self) -> MethodKind {
+    self.inner.kind
+  }
+
+  pub fn is_static(&self) -> bool {
+    self.inner.is_static
+  }
+
   /// Typescript extension.
-  pub accessibility: Option<Accessibility>,
+  pub fn accessibility(&self) -> Option<Accessibility> {
+    self.inner.accessibility
+  }
+
   /// Typescript extension.
-  pub is_abstract: bool,
-  pub is_optional: bool,
+  pub fn is_abstract(&self) -> bool {
+    self.inner.is_abstract
+  }
+
+  pub fn is_optional(&self) -> bool {
+    self.inner.is_optional
+  }
 }
 
 impl<'a> Spanned for ClassMethod<'a> {
@@ -7855,15 +7891,9 @@ impl<'a> CastableNode<'a> for ClassMethod<'a> {
 fn get_view_for_class_method<'a>(inner: &'a swc_ast::ClassMethod, parent: Node<'a>, bump: &'a Bump) -> &'a ClassMethod<'a> {
   let node = bump.alloc(ClassMethod {
     inner,
-    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
-    kind: inner.kind,
-    is_static: inner.is_static,
-    accessibility: inner.accessibility,
-    is_abstract: inner.is_abstract,
-    is_optional: inner.is_optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_prop_name(&inner.key, parent.clone(), bump);
@@ -7871,28 +7901,52 @@ fn get_view_for_class_method<'a>(inner: &'a swc_ast::ClassMethod, parent: Node<'
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableClassProp"))]
 pub struct ClassProp<'a> {
-  #[serde(skip)]
   pub parent: &'a Class<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ClassProp,
-  pub span: Span,
   pub key: Expr<'a>,
   pub value: Option<Expr<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub decorators: Vec<&'a Decorator<'a>>,
-  pub is_static: bool,
-  pub computed: bool,
+}
+
+impl<'a> ClassProp<'a> {
+  pub fn is_static(&self) -> bool {
+    self.inner.is_static
+  }
+
+  pub fn computed(&self) -> bool {
+    self.inner.computed
+  }
+
   /// Typescript extension.
-  pub accessibility: Option<Accessibility>,
+  pub fn accessibility(&self) -> Option<Accessibility> {
+    self.inner.accessibility
+  }
+
   /// Typescript extension.
-  pub is_abstract: bool,
-  pub is_optional: bool,
-  pub readonly: bool,
-  pub declare: bool,
-  pub definite: bool,
+  pub fn is_abstract(&self) -> bool {
+    self.inner.is_abstract
+  }
+
+  pub fn is_optional(&self) -> bool {
+    self.inner.is_optional
+  }
+
+  pub fn readonly(&self) -> bool {
+    self.inner.readonly
+  }
+
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
+
+  pub fn definite(&self) -> bool {
+    self.inner.definite
+  }
 }
 
 impl<'a> Spanned for ClassProp<'a> {
@@ -7953,20 +8007,11 @@ impl<'a> CastableNode<'a> for ClassProp<'a> {
 fn get_view_for_class_prop<'a>(inner: &'a swc_ast::ClassProp, parent: Node<'a>, bump: &'a Bump) -> &'a ClassProp<'a> {
   let node = bump.alloc(ClassProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
     type_ann: None,
     decorators: Vec::with_capacity(inner.decorators.len()),
-    is_static: inner.is_static,
-    computed: inner.computed,
-    accessibility: inner.accessibility,
-    is_abstract: inner.is_abstract,
-    is_optional: inner.is_optional,
-    readonly: inner.readonly,
-    declare: inner.declare,
-    definite: inner.definite,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_expr(&inner.key, parent.clone(), bump);
@@ -7982,14 +8027,12 @@ fn get_view_for_class_prop<'a>(inner: &'a swc_ast::ClassProp, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableComputedPropName"))]
 pub struct ComputedPropName<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ComputedPropName,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -8042,7 +8085,6 @@ impl<'a> CastableNode<'a> for ComputedPropName<'a> {
 fn get_view_for_computed_prop_name<'a>(inner: &'a swc_ast::ComputedPropName, parent: Node<'a>, bump: &'a Bump) -> &'a ComputedPropName<'a> {
   let node = bump.alloc(ComputedPropName {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8051,14 +8093,12 @@ fn get_view_for_computed_prop_name<'a>(inner: &'a swc_ast::ComputedPropName, par
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableCondExpr"))]
 pub struct CondExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::CondExpr,
-  pub span: Span,
   pub test: Expr<'a>,
   pub cons: Expr<'a>,
   pub alt: Expr<'a>,
@@ -8115,7 +8155,6 @@ impl<'a> CastableNode<'a> for CondExpr<'a> {
 fn get_view_for_cond_expr<'a>(inner: &'a swc_ast::CondExpr, parent: Node<'a>, bump: &'a Bump) -> &'a CondExpr<'a> {
   let node = bump.alloc(CondExpr {
     inner,
-    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     cons: unsafe { MaybeUninit::uninit().assume_init() },
@@ -8128,19 +8167,25 @@ fn get_view_for_cond_expr<'a>(inner: &'a swc_ast::CondExpr, parent: Node<'a>, bu
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableConstructor"))]
 pub struct Constructor<'a> {
-  #[serde(skip)]
   pub parent: &'a Class<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Constructor,
-  pub span: Span,
   pub key: PropName<'a>,
   pub params: Vec<ParamOrTsParamProp<'a>>,
   pub body: Option<&'a BlockStmt<'a>>,
-  pub accessibility: Option<Accessibility>,
-  pub is_optional: bool,
+}
+
+impl<'a> Constructor<'a> {
+  pub fn accessibility(&self) -> Option<Accessibility> {
+    self.inner.accessibility
+  }
+
+  pub fn is_optional(&self) -> bool {
+    self.inner.is_optional
+  }
 }
 
 impl<'a> Spanned for Constructor<'a> {
@@ -8198,13 +8243,10 @@ impl<'a> CastableNode<'a> for Constructor<'a> {
 fn get_view_for_constructor<'a>(inner: &'a swc_ast::Constructor, parent: Node<'a>, bump: &'a Bump) -> &'a Constructor<'a> {
   let node = bump.alloc(Constructor {
     inner,
-    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     params: Vec::with_capacity(inner.params.len()),
     body: None,
-    accessibility: inner.accessibility,
-    is_optional: inner.is_optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_prop_name(&inner.key, parent.clone(), bump);
@@ -8216,14 +8258,12 @@ fn get_view_for_constructor<'a>(inner: &'a swc_ast::Constructor, parent: Node<'a
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableContinueStmt"))]
 pub struct ContinueStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ContinueStmt,
-  pub span: Span,
   pub label: Option<&'a Ident<'a>>,
 }
 
@@ -8278,7 +8318,6 @@ impl<'a> CastableNode<'a> for ContinueStmt<'a> {
 fn get_view_for_continue_stmt<'a>(inner: &'a swc_ast::ContinueStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ContinueStmt<'a> {
   let node = bump.alloc(ContinueStmt {
     inner,
-    span: inner.span(),
     parent,
     label: None,
   });
@@ -8290,14 +8329,12 @@ fn get_view_for_continue_stmt<'a>(inner: &'a swc_ast::ContinueStmt, parent: Node
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableDebuggerStmt"))]
 pub struct DebuggerStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::DebuggerStmt,
-  pub span: Span,
 }
 
 impl<'a> Spanned for DebuggerStmt<'a> {
@@ -8347,20 +8384,17 @@ impl<'a> CastableNode<'a> for DebuggerStmt<'a> {
 fn get_view_for_debugger_stmt<'a>(inner: &'a swc_ast::DebuggerStmt, parent: Node<'a>, bump: &'a Bump) -> &'a DebuggerStmt<'a> {
   let node = bump.alloc(DebuggerStmt {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableDecorator"))]
 pub struct Decorator<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Decorator,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -8413,7 +8447,6 @@ impl<'a> CastableNode<'a> for Decorator<'a> {
 fn get_view_for_decorator<'a>(inner: &'a swc_ast::Decorator, parent: Node<'a>, bump: &'a Bump) -> &'a Decorator<'a> {
   let node = bump.alloc(Decorator {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8422,14 +8455,12 @@ fn get_view_for_decorator<'a>(inner: &'a swc_ast::Decorator, parent: Node<'a>, b
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableDoWhileStmt"))]
 pub struct DoWhileStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::DoWhileStmt,
-  pub span: Span,
   pub test: Expr<'a>,
   pub body: Stmt<'a>,
 }
@@ -8484,7 +8515,6 @@ impl<'a> CastableNode<'a> for DoWhileStmt<'a> {
 fn get_view_for_do_while_stmt<'a>(inner: &'a swc_ast::DoWhileStmt, parent: Node<'a>, bump: &'a Bump) -> &'a DoWhileStmt<'a> {
   let node = bump.alloc(DoWhileStmt {
     inner,
-    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -8495,14 +8525,12 @@ fn get_view_for_do_while_stmt<'a>(inner: &'a swc_ast::DoWhileStmt, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableEmptyStmt"))]
 pub struct EmptyStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::EmptyStmt,
-  pub span: Span,
 }
 
 impl<'a> Spanned for EmptyStmt<'a> {
@@ -8552,21 +8580,18 @@ impl<'a> CastableNode<'a> for EmptyStmt<'a> {
 fn get_view_for_empty_stmt<'a>(inner: &'a swc_ast::EmptyStmt, parent: Node<'a>, bump: &'a Bump) -> &'a EmptyStmt<'a> {
   let node = bump.alloc(EmptyStmt {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
 /// `export * from 'mod'`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExportAll"))]
 pub struct ExportAll<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExportAll,
-  pub span: Span,
   pub src: &'a Str<'a>,
   pub asserts: Option<&'a ObjectLit<'a>>,
 }
@@ -8623,7 +8648,6 @@ impl<'a> CastableNode<'a> for ExportAll<'a> {
 fn get_view_for_export_all<'a>(inner: &'a swc_ast::ExportAll, parent: Node<'a>, bump: &'a Bump) -> &'a ExportAll<'a> {
   let node = bump.alloc(ExportAll {
     inner,
-    span: inner.span(),
     parent,
     src: unsafe { MaybeUninit::uninit().assume_init() },
     asserts: None,
@@ -8637,14 +8661,12 @@ fn get_view_for_export_all<'a>(inner: &'a swc_ast::ExportAll, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExportDecl"))]
 pub struct ExportDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDecl,
-  pub span: Span,
   pub decl: Decl<'a>,
 }
 
@@ -8697,7 +8719,6 @@ impl<'a> CastableNode<'a> for ExportDecl<'a> {
 fn get_view_for_export_decl<'a>(inner: &'a swc_ast::ExportDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDecl<'a> {
   let node = bump.alloc(ExportDecl {
     inner,
-    span: inner.span(),
     parent,
     decl: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8706,14 +8727,12 @@ fn get_view_for_export_decl<'a>(inner: &'a swc_ast::ExportDecl, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExportDefaultDecl"))]
 pub struct ExportDefaultDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultDecl,
-  pub span: Span,
   pub decl: DefaultDecl<'a>,
 }
 
@@ -8766,7 +8785,6 @@ impl<'a> CastableNode<'a> for ExportDefaultDecl<'a> {
 fn get_view_for_export_default_decl<'a>(inner: &'a swc_ast::ExportDefaultDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDefaultDecl<'a> {
   let node = bump.alloc(ExportDefaultDecl {
     inner,
-    span: inner.span(),
     parent,
     decl: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8775,14 +8793,12 @@ fn get_view_for_export_default_decl<'a>(inner: &'a swc_ast::ExportDefaultDecl, p
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExportDefaultExpr"))]
 pub struct ExportDefaultExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultExpr,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -8835,7 +8851,6 @@ impl<'a> CastableNode<'a> for ExportDefaultExpr<'a> {
 fn get_view_for_export_default_expr<'a>(inner: &'a swc_ast::ExportDefaultExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDefaultExpr<'a> {
   let node = bump.alloc(ExportDefaultExpr {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8844,14 +8859,12 @@ fn get_view_for_export_default_expr<'a>(inner: &'a swc_ast::ExportDefaultExpr, p
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExportDefaultSpecifier"))]
 pub struct ExportDefaultSpecifier<'a> {
-  #[serde(skip)]
   pub parent: &'a NamedExport<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultSpecifier,
-  pub span: Span,
   pub exported: &'a Ident<'a>,
 }
 
@@ -8904,7 +8917,6 @@ impl<'a> CastableNode<'a> for ExportDefaultSpecifier<'a> {
 fn get_view_for_export_default_specifier<'a>(inner: &'a swc_ast::ExportDefaultSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDefaultSpecifier<'a> {
   let node = bump.alloc(ExportDefaultSpecifier {
     inner,
-    span: inner.span(),
     parent: parent.expect::<NamedExport>(),
     exported: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8913,14 +8925,12 @@ fn get_view_for_export_default_specifier<'a>(inner: &'a swc_ast::ExportDefaultSp
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExportNamedSpecifier"))]
 pub struct ExportNamedSpecifier<'a> {
-  #[serde(skip)]
   pub parent: &'a NamedExport<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExportNamedSpecifier,
-  pub span: Span,
   /// `foo` in `export { foo as bar }`
   pub orig: &'a Ident<'a>,
   /// `Some(bar)` in `export { foo as bar }`
@@ -8979,7 +8989,6 @@ impl<'a> CastableNode<'a> for ExportNamedSpecifier<'a> {
 fn get_view_for_export_named_specifier<'a>(inner: &'a swc_ast::ExportNamedSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ExportNamedSpecifier<'a> {
   let node = bump.alloc(ExportNamedSpecifier {
     inner,
-    span: inner.span(),
     parent: parent.expect::<NamedExport>(),
     orig: unsafe { MaybeUninit::uninit().assume_init() },
     exported: None,
@@ -8994,14 +9003,12 @@ fn get_view_for_export_named_specifier<'a>(inner: &'a swc_ast::ExportNamedSpecif
 }
 
 /// `export * as foo from 'src';`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExportNamespaceSpecifier"))]
 pub struct ExportNamespaceSpecifier<'a> {
-  #[serde(skip)]
   pub parent: &'a NamedExport<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExportNamespaceSpecifier,
-  pub span: Span,
   pub name: &'a Ident<'a>,
 }
 
@@ -9054,7 +9061,6 @@ impl<'a> CastableNode<'a> for ExportNamespaceSpecifier<'a> {
 fn get_view_for_export_namespace_specifier<'a>(inner: &'a swc_ast::ExportNamespaceSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ExportNamespaceSpecifier<'a> {
   let node = bump.alloc(ExportNamespaceSpecifier {
     inner,
-    span: inner.span(),
     parent: parent.expect::<NamedExport>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -9063,16 +9069,19 @@ fn get_view_for_export_namespace_specifier<'a>(inner: &'a swc_ast::ExportNamespa
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExprOrSpread"))]
 pub struct ExprOrSpread<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExprOrSpread,
-  pub span: Span,
   pub expr: Expr<'a>,
-  pub spread: &'a Option<swc_common::Span>,
+}
+
+impl<'a> ExprOrSpread<'a> {
+  pub fn spread(&self) -> &Option<swc_common::Span> {
+    &self.inner.spread
+  }
 }
 
 impl<'a> Spanned for ExprOrSpread<'a> {
@@ -9124,24 +9133,20 @@ impl<'a> CastableNode<'a> for ExprOrSpread<'a> {
 fn get_view_for_expr_or_spread<'a>(inner: &'a swc_ast::ExprOrSpread, parent: Node<'a>, bump: &'a Bump) -> &'a ExprOrSpread<'a> {
   let node = bump.alloc(ExprOrSpread {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
-    spread: &inner.spread,
   });
   let parent: Node<'a> = (&*node).into();
   node.expr = get_view_for_expr(&inner.expr, parent, bump);
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableExprStmt"))]
 pub struct ExprStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ExprStmt,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -9194,7 +9199,6 @@ impl<'a> CastableNode<'a> for ExprStmt<'a> {
 fn get_view_for_expr_stmt<'a>(inner: &'a swc_ast::ExprStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ExprStmt<'a> {
   let node = bump.alloc(ExprStmt {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -9203,17 +9207,20 @@ fn get_view_for_expr_stmt<'a>(inner: &'a swc_ast::ExprStmt, parent: Node<'a>, bu
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableFnDecl"))]
 pub struct FnDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::FnDecl,
-  pub span: Span,
   pub ident: &'a Ident<'a>,
   pub function: &'a Function<'a>,
-  pub declare: bool,
+}
+
+impl<'a> FnDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
 }
 
 impl<'a> Spanned for FnDecl<'a> {
@@ -9266,11 +9273,9 @@ impl<'a> CastableNode<'a> for FnDecl<'a> {
 fn get_view_for_fn_decl<'a>(inner: &'a swc_ast::FnDecl, parent: Node<'a>, bump: &'a Bump) -> &'a FnDecl<'a> {
   let node = bump.alloc(FnDecl {
     inner,
-    span: inner.span(),
     parent,
     ident: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
-    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.ident = get_view_for_ident(&inner.ident, parent.clone(), bump);
@@ -9279,14 +9284,12 @@ fn get_view_for_fn_decl<'a>(inner: &'a swc_ast::FnDecl, parent: Node<'a>, bump: 
 }
 
 /// Function expression.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableFnExpr"))]
 pub struct FnExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::FnExpr,
-  pub span: Span,
   pub ident: Option<&'a Ident<'a>>,
   pub function: &'a Function<'a>,
 }
@@ -9343,7 +9346,6 @@ impl<'a> CastableNode<'a> for FnExpr<'a> {
 fn get_view_for_fn_expr<'a>(inner: &'a swc_ast::FnExpr, parent: Node<'a>, bump: &'a Bump) -> &'a FnExpr<'a> {
   let node = bump.alloc(FnExpr {
     inner,
-    span: inner.span(),
     parent,
     ident: None,
     function: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9357,14 +9359,12 @@ fn get_view_for_fn_expr<'a>(inner: &'a swc_ast::FnExpr, parent: Node<'a>, bump: 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableForInStmt"))]
 pub struct ForInStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ForInStmt,
-  pub span: Span,
   pub left: VarDeclOrPat<'a>,
   pub right: Expr<'a>,
   pub body: Stmt<'a>,
@@ -9421,7 +9421,6 @@ impl<'a> CastableNode<'a> for ForInStmt<'a> {
 fn get_view_for_for_in_stmt<'a>(inner: &'a swc_ast::ForInStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ForInStmt<'a> {
   let node = bump.alloc(ForInStmt {
     inner,
-    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9434,23 +9433,26 @@ fn get_view_for_for_in_stmt<'a>(inner: &'a swc_ast::ForInStmt, parent: Node<'a>,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableForOfStmt"))]
 pub struct ForOfStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ForOfStmt,
-  pub span: Span,
   pub left: VarDeclOrPat<'a>,
   pub right: Expr<'a>,
   pub body: Stmt<'a>,
+}
+
+impl<'a> ForOfStmt<'a> {
   /// Span of the await token.
   ///
   /// es2018
   ///
   /// for-await-of statements, e.g., `for await (const x of xs) {`
-  pub await_token: &'a Option<swc_common::Span>,
+  pub fn await_token(&self) -> &Option<swc_common::Span> {
+    &self.inner.await_token
+  }
 }
 
 impl<'a> Spanned for ForOfStmt<'a> {
@@ -9504,12 +9506,10 @@ impl<'a> CastableNode<'a> for ForOfStmt<'a> {
 fn get_view_for_for_of_stmt<'a>(inner: &'a swc_ast::ForOfStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ForOfStmt<'a> {
   let node = bump.alloc(ForOfStmt {
     inner,
-    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
-    await_token: &inner.await_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.left = get_view_for_var_decl_or_pat(&inner.left, parent.clone(), bump);
@@ -9518,14 +9518,12 @@ fn get_view_for_for_of_stmt<'a>(inner: &'a swc_ast::ForOfStmt, parent: Node<'a>,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableForStmt"))]
 pub struct ForStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ForStmt,
-  pub span: Span,
   pub init: Option<VarDeclOrExpr<'a>>,
   pub test: Option<Expr<'a>>,
   pub update: Option<Expr<'a>>,
@@ -9590,7 +9588,6 @@ impl<'a> CastableNode<'a> for ForStmt<'a> {
 fn get_view_for_for_stmt<'a>(inner: &'a swc_ast::ForStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ForStmt<'a> {
   let node = bump.alloc(ForStmt {
     inner,
-    span: inner.span(),
     parent,
     init: None,
     test: None,
@@ -9615,23 +9612,29 @@ fn get_view_for_for_stmt<'a>(inner: &'a swc_ast::ForStmt, parent: Node<'a>, bump
 }
 
 /// Common parts of function and method.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableFunction"))]
 pub struct Function<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Function,
-  pub span: Span,
   pub params: Vec<&'a Param<'a>>,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub body: Option<&'a BlockStmt<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub return_type: Option<&'a TsTypeAnn<'a>>,
+}
+
+impl<'a> Function<'a> {
   /// if it's a generator.
-  pub is_generator: bool,
+  pub fn is_generator(&self) -> bool {
+    self.inner.is_generator
+  }
+
   /// if it's an async function.
-  pub is_async: bool,
+  pub fn is_async(&self) -> bool {
+    self.inner.is_async
+  }
 }
 
 impl<'a> Spanned for Function<'a> {
@@ -9697,15 +9700,12 @@ impl<'a> CastableNode<'a> for Function<'a> {
 fn get_view_for_function<'a>(inner: &'a swc_ast::Function, parent: Node<'a>, bump: &'a Bump) -> &'a Function<'a> {
   let node = bump.alloc(Function {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     decorators: Vec::with_capacity(inner.decorators.len()),
     body: None,
     type_params: None,
     return_type: None,
-    is_generator: inner.is_generator,
-    is_async: inner.is_async,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_param(value, parent.clone(), bump)));
@@ -9725,14 +9725,12 @@ fn get_view_for_function<'a>(inner: &'a swc_ast::Function, parent: Node<'a>, bum
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableGetterProp"))]
 pub struct GetterProp<'a> {
-  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::GetterProp,
-  pub span: Span,
   pub key: PropName<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub body: Option<&'a BlockStmt<'a>>,
@@ -9793,7 +9791,6 @@ impl<'a> CastableNode<'a> for GetterProp<'a> {
 fn get_view_for_getter_prop<'a>(inner: &'a swc_ast::GetterProp, parent: Node<'a>, bump: &'a Bump) -> &'a GetterProp<'a> {
   let node = bump.alloc(GetterProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
@@ -9813,17 +9810,23 @@ fn get_view_for_getter_prop<'a>(inner: &'a swc_ast::GetterProp, parent: Node<'a>
 }
 
 /// Ident with span.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableIdent"))]
 pub struct Ident<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Ident,
-  pub span: Span,
-  pub sym: &'a swc_atoms::JsWord,
+}
+
+impl<'a> Ident<'a> {
+  pub fn sym(&self) -> &swc_atoms::JsWord {
+    &self.inner.sym
+  }
+
   /// TypeScript only. Used in case of an optional parameter.
-  pub optional: bool,
+  pub fn optional(&self) -> bool {
+    self.inner.optional
+  }
 }
 
 impl<'a> Spanned for Ident<'a> {
@@ -9873,22 +9876,17 @@ impl<'a> CastableNode<'a> for Ident<'a> {
 fn get_view_for_ident<'a>(inner: &'a swc_ast::Ident, parent: Node<'a>, bump: &'a Bump) -> &'a Ident<'a> {
   let node = bump.alloc(Ident {
     inner,
-    span: inner.span(),
     parent,
-    sym: &inner.sym,
-    optional: inner.optional,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableIfStmt"))]
 pub struct IfStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::IfStmt,
-  pub span: Span,
   pub test: Expr<'a>,
   pub cons: Stmt<'a>,
   pub alt: Option<Stmt<'a>>,
@@ -9947,7 +9945,6 @@ impl<'a> CastableNode<'a> for IfStmt<'a> {
 fn get_view_for_if_stmt<'a>(inner: &'a swc_ast::IfStmt, parent: Node<'a>, bump: &'a Bump) -> &'a IfStmt<'a> {
   let node = bump.alloc(IfStmt {
     inner,
-    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     cons: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9963,18 +9960,21 @@ fn get_view_for_if_stmt<'a>(inner: &'a swc_ast::IfStmt, parent: Node<'a>, bump: 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableImportDecl"))]
 pub struct ImportDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ImportDecl,
-  pub span: Span,
   pub specifiers: Vec<ImportSpecifier<'a>>,
   pub src: &'a Str<'a>,
   pub asserts: Option<&'a ObjectLit<'a>>,
-  pub type_only: bool,
+}
+
+impl<'a> ImportDecl<'a> {
+  pub fn type_only(&self) -> bool {
+    self.inner.type_only
+  }
 }
 
 impl<'a> Spanned for ImportDecl<'a> {
@@ -10032,12 +10032,10 @@ impl<'a> CastableNode<'a> for ImportDecl<'a> {
 fn get_view_for_import_decl<'a>(inner: &'a swc_ast::ImportDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ImportDecl<'a> {
   let node = bump.alloc(ImportDecl {
     inner,
-    span: inner.span(),
     parent,
     specifiers: Vec::with_capacity(inner.specifiers.len()),
     src: unsafe { MaybeUninit::uninit().assume_init() },
     asserts: None,
-    type_only: inner.type_only,
   });
   let parent: Node<'a> = (&*node).into();
   node.specifiers.extend(inner.specifiers.iter().map(|value| get_view_for_import_specifier(value, parent.clone(), bump)));
@@ -10050,14 +10048,12 @@ fn get_view_for_import_decl<'a>(inner: &'a swc_ast::ImportDecl, parent: Node<'a>
 }
 
 /// e.g. `import foo from 'mod.js'`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableImportDefaultSpecifier"))]
 pub struct ImportDefaultSpecifier<'a> {
-  #[serde(skip)]
   pub parent: &'a ImportDecl<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ImportDefaultSpecifier,
-  pub span: Span,
   pub local: &'a Ident<'a>,
 }
 
@@ -10110,7 +10106,6 @@ impl<'a> CastableNode<'a> for ImportDefaultSpecifier<'a> {
 fn get_view_for_import_default_specifier<'a>(inner: &'a swc_ast::ImportDefaultSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ImportDefaultSpecifier<'a> {
   let node = bump.alloc(ImportDefaultSpecifier {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ImportDecl>(),
     local: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10122,14 +10117,12 @@ fn get_view_for_import_default_specifier<'a>(inner: &'a swc_ast::ImportDefaultSp
 /// e.g. local = foo, imported = None `import { foo } from 'mod.js'`
 /// e.g. local = bar, imported = Some(foo) for `import { foo as bar } from
 /// 'mod.js'`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableImportNamedSpecifier"))]
 pub struct ImportNamedSpecifier<'a> {
-  #[serde(skip)]
   pub parent: &'a ImportDecl<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ImportNamedSpecifier,
-  pub span: Span,
   pub local: &'a Ident<'a>,
   pub imported: Option<&'a Ident<'a>>,
 }
@@ -10186,7 +10179,6 @@ impl<'a> CastableNode<'a> for ImportNamedSpecifier<'a> {
 fn get_view_for_import_named_specifier<'a>(inner: &'a swc_ast::ImportNamedSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ImportNamedSpecifier<'a> {
   let node = bump.alloc(ImportNamedSpecifier {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ImportDecl>(),
     local: unsafe { MaybeUninit::uninit().assume_init() },
     imported: None,
@@ -10201,14 +10193,12 @@ fn get_view_for_import_named_specifier<'a>(inner: &'a swc_ast::ImportNamedSpecif
 }
 
 /// e.g. `import * as foo from 'mod.js'`.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableImportStarAsSpecifier"))]
 pub struct ImportStarAsSpecifier<'a> {
-  #[serde(skip)]
   pub parent: &'a ImportDecl<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ImportStarAsSpecifier,
-  pub span: Span,
   pub local: &'a Ident<'a>,
 }
 
@@ -10261,7 +10251,6 @@ impl<'a> CastableNode<'a> for ImportStarAsSpecifier<'a> {
 fn get_view_for_import_star_as_specifier<'a>(inner: &'a swc_ast::ImportStarAsSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ImportStarAsSpecifier<'a> {
   let node = bump.alloc(ImportStarAsSpecifier {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ImportDecl>(),
     local: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10271,14 +10260,12 @@ fn get_view_for_import_star_as_specifier<'a>(inner: &'a swc_ast::ImportStarAsSpe
 }
 
 /// Represents a invalid node.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableInvalid"))]
 pub struct Invalid<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Invalid,
-  pub span: Span,
 }
 
 impl<'a> Spanned for Invalid<'a> {
@@ -10328,20 +10315,17 @@ impl<'a> CastableNode<'a> for Invalid<'a> {
 fn get_view_for_invalid<'a>(inner: &'a swc_ast::Invalid, parent: Node<'a>, bump: &'a Bump) -> &'a Invalid<'a> {
   let node = bump.alloc(Invalid {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXAttr"))]
 pub struct JSXAttr<'a> {
-  #[serde(skip)]
   pub parent: &'a JSXOpeningElement<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXAttr,
-  pub span: Span,
   pub name: JSXAttrName<'a>,
   /// Babel uses Expr instead of JSXAttrValue
   pub value: Option<JSXAttrValue<'a>>,
@@ -10399,7 +10383,6 @@ impl<'a> CastableNode<'a> for JSXAttr<'a> {
 fn get_view_for_jsxattr<'a>(inner: &'a swc_ast::JSXAttr, parent: Node<'a>, bump: &'a Bump) -> &'a JSXAttr<'a> {
   let node = bump.alloc(JSXAttr {
     inner,
-    span: inner.span(),
     parent: parent.expect::<JSXOpeningElement>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
@@ -10413,14 +10396,12 @@ fn get_view_for_jsxattr<'a>(inner: &'a swc_ast::JSXAttr, parent: Node<'a>, bump:
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXClosingElement"))]
 pub struct JSXClosingElement<'a> {
-  #[serde(skip)]
   pub parent: &'a JSXElement<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXClosingElement,
-  pub span: Span,
   pub name: JSXElementName<'a>,
 }
 
@@ -10473,7 +10454,6 @@ impl<'a> CastableNode<'a> for JSXClosingElement<'a> {
 fn get_view_for_jsxclosing_element<'a>(inner: &'a swc_ast::JSXClosingElement, parent: Node<'a>, bump: &'a Bump) -> &'a JSXClosingElement<'a> {
   let node = bump.alloc(JSXClosingElement {
     inner,
-    span: inner.span(),
     parent: parent.expect::<JSXElement>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10482,14 +10462,12 @@ fn get_view_for_jsxclosing_element<'a>(inner: &'a swc_ast::JSXClosingElement, pa
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXClosingFragment"))]
 pub struct JSXClosingFragment<'a> {
-  #[serde(skip)]
   pub parent: &'a JSXFragment<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXClosingFragment,
-  pub span: Span,
 }
 
 impl<'a> Spanned for JSXClosingFragment<'a> {
@@ -10539,20 +10517,17 @@ impl<'a> CastableNode<'a> for JSXClosingFragment<'a> {
 fn get_view_for_jsxclosing_fragment<'a>(inner: &'a swc_ast::JSXClosingFragment, parent: Node<'a>, bump: &'a Bump) -> &'a JSXClosingFragment<'a> {
   let node = bump.alloc(JSXClosingFragment {
     inner,
-    span: inner.span(),
     parent: parent.expect::<JSXFragment>(),
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXElement"))]
 pub struct JSXElement<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXElement,
-  pub span: Span,
   pub opening: &'a JSXOpeningElement<'a>,
   pub children: Vec<JSXElementChild<'a>>,
   pub closing: Option<&'a JSXClosingElement<'a>>,
@@ -10613,7 +10588,6 @@ impl<'a> CastableNode<'a> for JSXElement<'a> {
 fn get_view_for_jsxelement<'a>(inner: &'a swc_ast::JSXElement, parent: Node<'a>, bump: &'a Bump) -> &'a JSXElement<'a> {
   let node = bump.alloc(JSXElement {
     inner,
-    span: inner.span(),
     parent,
     opening: unsafe { MaybeUninit::uninit().assume_init() },
     children: Vec::with_capacity(inner.children.len()),
@@ -10629,14 +10603,12 @@ fn get_view_for_jsxelement<'a>(inner: &'a swc_ast::JSXElement, parent: Node<'a>,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXEmptyExpr"))]
 pub struct JSXEmptyExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXEmptyExpr,
-  pub span: Span,
 }
 
 impl<'a> Spanned for JSXEmptyExpr<'a> {
@@ -10686,20 +10658,17 @@ impl<'a> CastableNode<'a> for JSXEmptyExpr<'a> {
 fn get_view_for_jsxempty_expr<'a>(inner: &'a swc_ast::JSXEmptyExpr, parent: Node<'a>, bump: &'a Bump) -> &'a JSXEmptyExpr<'a> {
   let node = bump.alloc(JSXEmptyExpr {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXExprContainer"))]
 pub struct JSXExprContainer<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXExprContainer,
-  pub span: Span,
   pub expr: JSXExpr<'a>,
 }
 
@@ -10752,7 +10721,6 @@ impl<'a> CastableNode<'a> for JSXExprContainer<'a> {
 fn get_view_for_jsxexpr_container<'a>(inner: &'a swc_ast::JSXExprContainer, parent: Node<'a>, bump: &'a Bump) -> &'a JSXExprContainer<'a> {
   let node = bump.alloc(JSXExprContainer {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10761,14 +10729,12 @@ fn get_view_for_jsxexpr_container<'a>(inner: &'a swc_ast::JSXExprContainer, pare
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXFragment"))]
 pub struct JSXFragment<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXFragment,
-  pub span: Span,
   pub opening: &'a JSXOpeningFragment<'a>,
   pub children: Vec<JSXElementChild<'a>>,
   pub closing: &'a JSXClosingFragment<'a>,
@@ -10827,7 +10793,6 @@ impl<'a> CastableNode<'a> for JSXFragment<'a> {
 fn get_view_for_jsxfragment<'a>(inner: &'a swc_ast::JSXFragment, parent: Node<'a>, bump: &'a Bump) -> &'a JSXFragment<'a> {
   let node = bump.alloc(JSXFragment {
     inner,
-    span: inner.span(),
     parent,
     opening: unsafe { MaybeUninit::uninit().assume_init() },
     children: Vec::with_capacity(inner.children.len()),
@@ -10840,14 +10805,12 @@ fn get_view_for_jsxfragment<'a>(inner: &'a swc_ast::JSXFragment, parent: Node<'a
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXMemberExpr"))]
 pub struct JSXMemberExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXMemberExpr,
-  pub span: Span,
   pub obj: JSXObject<'a>,
   pub prop: &'a Ident<'a>,
 }
@@ -10902,7 +10865,6 @@ impl<'a> CastableNode<'a> for JSXMemberExpr<'a> {
 fn get_view_for_jsxmember_expr<'a>(inner: &'a swc_ast::JSXMemberExpr, parent: Node<'a>, bump: &'a Bump) -> &'a JSXMemberExpr<'a> {
   let node = bump.alloc(JSXMemberExpr {
     inner,
-    span: inner.span(),
     parent,
     obj: unsafe { MaybeUninit::uninit().assume_init() },
     prop: unsafe { MaybeUninit::uninit().assume_init() },
@@ -10914,14 +10876,12 @@ fn get_view_for_jsxmember_expr<'a>(inner: &'a swc_ast::JSXMemberExpr, parent: No
 }
 
 /// XML-based namespace syntax:
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXNamespacedName"))]
 pub struct JSXNamespacedName<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXNamespacedName,
-  pub span: Span,
   pub ns: &'a Ident<'a>,
   pub name: &'a Ident<'a>,
 }
@@ -10976,7 +10936,6 @@ impl<'a> CastableNode<'a> for JSXNamespacedName<'a> {
 fn get_view_for_jsxnamespaced_name<'a>(inner: &'a swc_ast::JSXNamespacedName, parent: Node<'a>, bump: &'a Bump) -> &'a JSXNamespacedName<'a> {
   let node = bump.alloc(JSXNamespacedName {
     inner,
-    span: inner.span(),
     parent,
     ns: unsafe { MaybeUninit::uninit().assume_init() },
     name: unsafe { MaybeUninit::uninit().assume_init() },
@@ -10987,20 +10946,23 @@ fn get_view_for_jsxnamespaced_name<'a>(inner: &'a swc_ast::JSXNamespacedName, pa
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXOpeningElement"))]
 pub struct JSXOpeningElement<'a> {
-  #[serde(skip)]
   pub parent: &'a JSXElement<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXOpeningElement,
-  pub span: Span,
   pub name: JSXElementName<'a>,
   pub attrs: Vec<JSXAttrOrSpread<'a>>,
   /// Note: This field's name is different from one from babel because it is
   /// misleading
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
-  pub self_closing: bool,
+}
+
+impl<'a> JSXOpeningElement<'a> {
+  pub fn self_closing(&self) -> bool {
+    self.inner.self_closing
+  }
 }
 
 impl<'a> Spanned for JSXOpeningElement<'a> {
@@ -11058,12 +11020,10 @@ impl<'a> CastableNode<'a> for JSXOpeningElement<'a> {
 fn get_view_for_jsxopening_element<'a>(inner: &'a swc_ast::JSXOpeningElement, parent: Node<'a>, bump: &'a Bump) -> &'a JSXOpeningElement<'a> {
   let node = bump.alloc(JSXOpeningElement {
     inner,
-    span: inner.span(),
     parent: parent.expect::<JSXElement>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
     attrs: Vec::with_capacity(inner.attrs.len()),
     type_args: None,
-    self_closing: inner.self_closing,
   });
   let parent: Node<'a> = (&*node).into();
   node.name = get_view_for_jsxelement_name(&inner.name, parent.clone(), bump);
@@ -11075,14 +11035,12 @@ fn get_view_for_jsxopening_element<'a>(inner: &'a swc_ast::JSXOpeningElement, pa
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXOpeningFragment"))]
 pub struct JSXOpeningFragment<'a> {
-  #[serde(skip)]
   pub parent: &'a JSXFragment<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXOpeningFragment,
-  pub span: Span,
 }
 
 impl<'a> Spanned for JSXOpeningFragment<'a> {
@@ -11132,20 +11090,17 @@ impl<'a> CastableNode<'a> for JSXOpeningFragment<'a> {
 fn get_view_for_jsxopening_fragment<'a>(inner: &'a swc_ast::JSXOpeningFragment, parent: Node<'a>, bump: &'a Bump) -> &'a JSXOpeningFragment<'a> {
   let node = bump.alloc(JSXOpeningFragment {
     inner,
-    span: inner.span(),
     parent: parent.expect::<JSXFragment>(),
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXSpreadChild"))]
 pub struct JSXSpreadChild<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXSpreadChild,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -11198,7 +11153,6 @@ impl<'a> CastableNode<'a> for JSXSpreadChild<'a> {
 fn get_view_for_jsxspread_child<'a>(inner: &'a swc_ast::JSXSpreadChild, parent: Node<'a>, bump: &'a Bump) -> &'a JSXSpreadChild<'a> {
   let node = bump.alloc(JSXSpreadChild {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -11207,16 +11161,22 @@ fn get_view_for_jsxspread_child<'a>(inner: &'a swc_ast::JSXSpreadChild, parent: 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableJSXText"))]
 pub struct JSXText<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::JSXText,
-  pub span: Span,
-  pub value: &'a swc_atoms::JsWord,
-  pub raw: &'a swc_atoms::JsWord,
+}
+
+impl<'a> JSXText<'a> {
+  pub fn value(&self) -> &swc_atoms::JsWord {
+    &self.inner.value
+  }
+
+  pub fn raw(&self) -> &swc_atoms::JsWord {
+    &self.inner.raw
+  }
 }
 
 impl<'a> Spanned for JSXText<'a> {
@@ -11266,23 +11226,18 @@ impl<'a> CastableNode<'a> for JSXText<'a> {
 fn get_view_for_jsxtext<'a>(inner: &'a swc_ast::JSXText, parent: Node<'a>, bump: &'a Bump) -> &'a JSXText<'a> {
   let node = bump.alloc(JSXText {
     inner,
-    span: inner.span(),
     parent,
-    value: &inner.value,
-    raw: &inner.raw,
   });
   node
 }
 
 /// `{key: value}`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableKeyValuePatProp"))]
 pub struct KeyValuePatProp<'a> {
-  #[serde(skip)]
   pub parent: &'a ObjectPat<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::KeyValuePatProp,
-  pub span: Span,
   pub key: PropName<'a>,
   pub value: Pat<'a>,
 }
@@ -11337,7 +11292,6 @@ impl<'a> CastableNode<'a> for KeyValuePatProp<'a> {
 fn get_view_for_key_value_pat_prop<'a>(inner: &'a swc_ast::KeyValuePatProp, parent: Node<'a>, bump: &'a Bump) -> &'a KeyValuePatProp<'a> {
   let node = bump.alloc(KeyValuePatProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ObjectPat>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11348,14 +11302,12 @@ fn get_view_for_key_value_pat_prop<'a>(inner: &'a swc_ast::KeyValuePatProp, pare
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableKeyValueProp"))]
 pub struct KeyValueProp<'a> {
-  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::KeyValueProp,
-  pub span: Span,
   pub key: PropName<'a>,
   pub value: Expr<'a>,
 }
@@ -11410,7 +11362,6 @@ impl<'a> CastableNode<'a> for KeyValueProp<'a> {
 fn get_view_for_key_value_prop<'a>(inner: &'a swc_ast::KeyValueProp, parent: Node<'a>, bump: &'a Bump) -> &'a KeyValueProp<'a> {
   let node = bump.alloc(KeyValueProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11421,14 +11372,12 @@ fn get_view_for_key_value_prop<'a>(inner: &'a swc_ast::KeyValueProp, parent: Nod
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableLabeledStmt"))]
 pub struct LabeledStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::LabeledStmt,
-  pub span: Span,
   pub label: &'a Ident<'a>,
   pub body: Stmt<'a>,
 }
@@ -11483,7 +11432,6 @@ impl<'a> CastableNode<'a> for LabeledStmt<'a> {
 fn get_view_for_labeled_stmt<'a>(inner: &'a swc_ast::LabeledStmt, parent: Node<'a>, bump: &'a Bump) -> &'a LabeledStmt<'a> {
   let node = bump.alloc(LabeledStmt {
     inner,
-    span: inner.span(),
     parent,
     label: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11494,17 +11442,20 @@ fn get_view_for_labeled_stmt<'a>(inner: &'a swc_ast::LabeledStmt, parent: Node<'
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableMemberExpr"))]
 pub struct MemberExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::MemberExpr,
-  pub span: Span,
   pub obj: ExprOrSuper<'a>,
   pub prop: Expr<'a>,
-  pub computed: bool,
+}
+
+impl<'a> MemberExpr<'a> {
+  pub fn computed(&self) -> bool {
+    self.inner.computed
+  }
 }
 
 impl<'a> Spanned for MemberExpr<'a> {
@@ -11557,11 +11508,9 @@ impl<'a> CastableNode<'a> for MemberExpr<'a> {
 fn get_view_for_member_expr<'a>(inner: &'a swc_ast::MemberExpr, parent: Node<'a>, bump: &'a Bump) -> &'a MemberExpr<'a> {
   let node = bump.alloc(MemberExpr {
     inner,
-    span: inner.span(),
     parent,
     obj: unsafe { MaybeUninit::uninit().assume_init() },
     prop: unsafe { MaybeUninit::uninit().assume_init() },
-    computed: inner.computed,
   });
   let parent: Node<'a> = (&*node).into();
   node.obj = get_view_for_expr_or_super(&inner.obj, parent.clone(), bump);
@@ -11569,14 +11518,12 @@ fn get_view_for_member_expr<'a>(inner: &'a swc_ast::MemberExpr, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableMetaPropExpr"))]
 pub struct MetaPropExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::MetaPropExpr,
-  pub span: Span,
   pub meta: &'a Ident<'a>,
   pub prop: &'a Ident<'a>,
 }
@@ -11631,7 +11578,6 @@ impl<'a> CastableNode<'a> for MetaPropExpr<'a> {
 fn get_view_for_meta_prop_expr<'a>(inner: &'a swc_ast::MetaPropExpr, parent: Node<'a>, bump: &'a Bump) -> &'a MetaPropExpr<'a> {
   let node = bump.alloc(MetaPropExpr {
     inner,
-    span: inner.span(),
     parent,
     meta: unsafe { MaybeUninit::uninit().assume_init() },
     prop: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11642,14 +11588,12 @@ fn get_view_for_meta_prop_expr<'a>(inner: &'a swc_ast::MetaPropExpr, parent: Nod
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableMethodProp"))]
 pub struct MethodProp<'a> {
-  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::MethodProp,
-  pub span: Span,
   pub key: PropName<'a>,
   pub function: &'a Function<'a>,
 }
@@ -11704,7 +11648,6 @@ impl<'a> CastableNode<'a> for MethodProp<'a> {
 fn get_view_for_method_prop<'a>(inner: &'a swc_ast::MethodProp, parent: Node<'a>, bump: &'a Bump) -> &'a MethodProp<'a> {
   let node = bump.alloc(MethodProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11715,20 +11658,21 @@ fn get_view_for_method_prop<'a>(inner: &'a swc_ast::MethodProp, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableModule"))]
 pub struct Module<'a> {
-  #[serde(skip)]
   pub source_file: Option<&'a swc_common::SourceFile>,
-  #[serde(skip)]
   pub tokens: Option<&'a TokenContainer<'a>>,
-  #[serde(skip)]
   pub comments: Option<&'a CommentContainer<'a>>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Module,
-  pub span: Span,
   pub body: Vec<ModuleItem<'a>>,
-  pub shebang: &'a Option<swc_atoms::JsWord>,
+}
+
+impl<'a> Module<'a> {
+  pub fn shebang(&self) -> &Option<swc_atoms::JsWord> {
+    &self.inner.shebang
+  }
 }
 
 impl<'a> Spanned for Module<'a> {
@@ -11789,12 +11733,10 @@ fn get_view_for_module<'a>(source_file_info: &'a ModuleInfo<'a>, bump: &'a Bump)
   )));
   let node = bump.alloc(Module {
     inner,
-    span: inner.span(),
     source_file: source_file_info.source_file,
     tokens,
     comments,
     body: Vec::with_capacity(inner.body.len()),
-    shebang: &inner.shebang,
   });
   let parent: Node<'a> = (&*node).into();
   node.body.extend(inner.body.iter().map(|value| get_view_for_module_item(value, parent.clone(), bump)));
@@ -11803,18 +11745,21 @@ fn get_view_for_module<'a>(source_file_info: &'a ModuleInfo<'a>, bump: &'a Bump)
 
 /// `export { foo } from 'mod'`
 /// `export { foo as bar } from 'mod'`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableNamedExport"))]
 pub struct NamedExport<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::NamedExport,
-  pub span: Span,
   pub specifiers: Vec<ExportSpecifier<'a>>,
   pub src: Option<&'a Str<'a>>,
   pub asserts: Option<&'a ObjectLit<'a>>,
-  pub type_only: bool,
+}
+
+impl<'a> NamedExport<'a> {
+  pub fn type_only(&self) -> bool {
+    self.inner.type_only
+  }
 }
 
 impl<'a> Spanned for NamedExport<'a> {
@@ -11874,12 +11819,10 @@ impl<'a> CastableNode<'a> for NamedExport<'a> {
 fn get_view_for_named_export<'a>(inner: &'a swc_ast::NamedExport, parent: Node<'a>, bump: &'a Bump) -> &'a NamedExport<'a> {
   let node = bump.alloc(NamedExport {
     inner,
-    span: inner.span(),
     parent,
     specifiers: Vec::with_capacity(inner.specifiers.len()),
     src: None,
     asserts: None,
-    type_only: inner.type_only,
   });
   let parent: Node<'a> = (&*node).into();
   node.specifiers.extend(inner.specifiers.iter().map(|value| get_view_for_export_specifier(value, parent.clone(), bump)));
@@ -11894,14 +11837,12 @@ fn get_view_for_named_export<'a>(inner: &'a swc_ast::NamedExport, parent: Node<'
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableNewExpr"))]
 pub struct NewExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::NewExpr,
-  pub span: Span,
   pub callee: Expr<'a>,
   pub args: Option<Vec<&'a ExprOrSpread<'a>>>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -11964,7 +11905,6 @@ impl<'a> CastableNode<'a> for NewExpr<'a> {
 fn get_view_for_new_expr<'a>(inner: &'a swc_ast::NewExpr, parent: Node<'a>, bump: &'a Bump) -> &'a NewExpr<'a> {
   let node = bump.alloc(NewExpr {
     inner,
-    span: inner.span(),
     parent,
     callee: unsafe { MaybeUninit::uninit().assume_init() },
     args: None,
@@ -11983,14 +11923,12 @@ fn get_view_for_new_expr<'a>(inner: &'a swc_ast::NewExpr, parent: Node<'a>, bump
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableNull"))]
 pub struct Null<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Null,
-  pub span: Span,
 }
 
 impl<'a> Spanned for Null<'a> {
@@ -12040,24 +11978,26 @@ impl<'a> CastableNode<'a> for Null<'a> {
 fn get_view_for_null<'a>(inner: &'a swc_ast::Null, parent: Node<'a>, bump: &'a Bump) -> &'a Null<'a> {
   let node = bump.alloc(Null {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableNumber"))]
 pub struct Number<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Number,
-  pub span: Span,
+}
+
+impl<'a> Number<'a> {
   /// **Note**: This should not be `NaN`. Use [crate::Ident] to represent NaN.
   ///
   /// If you store `NaN` in this field, a hash map will behave strangely.
-  pub value: f64,
+  pub fn value(&self) -> f64 {
+    self.inner.value
+  }
 }
 
 impl<'a> Spanned for Number<'a> {
@@ -12107,22 +12047,18 @@ impl<'a> CastableNode<'a> for Number<'a> {
 fn get_view_for_number<'a>(inner: &'a swc_ast::Number, parent: Node<'a>, bump: &'a Bump) -> &'a Number<'a> {
   let node = bump.alloc(Number {
     inner,
-    span: inner.span(),
     parent,
-    value: inner.value,
   });
   node
 }
 
 /// Object literal.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableObjectLit"))]
 pub struct ObjectLit<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ObjectLit,
-  pub span: Span,
   pub props: Vec<PropOrSpread<'a>>,
 }
 
@@ -12177,7 +12113,6 @@ impl<'a> CastableNode<'a> for ObjectLit<'a> {
 fn get_view_for_object_lit<'a>(inner: &'a swc_ast::ObjectLit, parent: Node<'a>, bump: &'a Bump) -> &'a ObjectLit<'a> {
   let node = bump.alloc(ObjectLit {
     inner,
-    span: inner.span(),
     parent,
     props: Vec::with_capacity(inner.props.len()),
   });
@@ -12186,18 +12121,21 @@ fn get_view_for_object_lit<'a>(inner: &'a swc_ast::ObjectLit, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableObjectPat"))]
 pub struct ObjectPat<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ObjectPat,
-  pub span: Span,
   pub props: Vec<ObjectPatProp<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
+}
+
+impl<'a> ObjectPat<'a> {
   /// Only in an ambient context
-  pub optional: bool,
+  pub fn optional(&self) -> bool {
+    self.inner.optional
+  }
 }
 
 impl<'a> Spanned for ObjectPat<'a> {
@@ -12254,11 +12192,9 @@ impl<'a> CastableNode<'a> for ObjectPat<'a> {
 fn get_view_for_object_pat<'a>(inner: &'a swc_ast::ObjectPat, parent: Node<'a>, bump: &'a Bump) -> &'a ObjectPat<'a> {
   let node = bump.alloc(ObjectPat {
     inner,
-    span: inner.span(),
     parent,
     props: Vec::with_capacity(inner.props.len()),
     type_ann: None,
-    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.props.extend(inner.props.iter().map(|value| get_view_for_object_pat_prop(value, parent.clone(), bump)));
@@ -12269,16 +12205,19 @@ fn get_view_for_object_pat<'a>(inner: &'a swc_ast::ObjectPat, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableOptChainExpr"))]
 pub struct OptChainExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::OptChainExpr,
-  pub span: Span,
   pub expr: Expr<'a>,
-  pub question_dot_token: &'a swc_common::Span,
+}
+
+impl<'a> OptChainExpr<'a> {
+  pub fn question_dot_token(&self) -> &swc_common::Span {
+    &self.inner.question_dot_token
+  }
 }
 
 impl<'a> Spanned for OptChainExpr<'a> {
@@ -12330,24 +12269,20 @@ impl<'a> CastableNode<'a> for OptChainExpr<'a> {
 fn get_view_for_opt_chain_expr<'a>(inner: &'a swc_ast::OptChainExpr, parent: Node<'a>, bump: &'a Bump) -> &'a OptChainExpr<'a> {
   let node = bump.alloc(OptChainExpr {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
-    question_dot_token: &inner.question_dot_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.expr = get_view_for_expr(&inner.expr, parent, bump);
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableParam"))]
 pub struct Param<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Param,
-  pub span: Span,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub pat: Pat<'a>,
 }
@@ -12404,7 +12339,6 @@ impl<'a> CastableNode<'a> for Param<'a> {
 fn get_view_for_param<'a>(inner: &'a swc_ast::Param, parent: Node<'a>, bump: &'a Bump) -> &'a Param<'a> {
   let node = bump.alloc(Param {
     inner,
-    span: inner.span(),
     parent,
     decorators: Vec::with_capacity(inner.decorators.len()),
     pat: unsafe { MaybeUninit::uninit().assume_init() },
@@ -12415,14 +12349,12 @@ fn get_view_for_param<'a>(inner: &'a swc_ast::Param, parent: Node<'a>, bump: &'a
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableParenExpr"))]
 pub struct ParenExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ParenExpr,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -12475,7 +12407,6 @@ impl<'a> CastableNode<'a> for ParenExpr<'a> {
 fn get_view_for_paren_expr<'a>(inner: &'a swc_ast::ParenExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ParenExpr<'a> {
   let node = bump.alloc(ParenExpr {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -12484,23 +12415,38 @@ fn get_view_for_paren_expr<'a>(inner: &'a swc_ast::ParenExpr, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializablePrivateMethod"))]
 pub struct PrivateMethod<'a> {
-  #[serde(skip)]
   pub parent: &'a Class<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::PrivateMethod,
-  pub span: Span,
   pub key: &'a PrivateName<'a>,
   pub function: &'a Function<'a>,
-  pub kind: MethodKind,
-  pub is_static: bool,
+}
+
+impl<'a> PrivateMethod<'a> {
+  pub fn kind(&self) -> MethodKind {
+    self.inner.kind
+  }
+
+  pub fn is_static(&self) -> bool {
+    self.inner.is_static
+  }
+
   /// Typescript extension.
-  pub accessibility: Option<Accessibility>,
+  pub fn accessibility(&self) -> Option<Accessibility> {
+    self.inner.accessibility
+  }
+
   /// Typescript extension.
-  pub is_abstract: bool,
-  pub is_optional: bool,
+  pub fn is_abstract(&self) -> bool {
+    self.inner.is_abstract
+  }
+
+  pub fn is_optional(&self) -> bool {
+    self.inner.is_optional
+  }
 }
 
 impl<'a> Spanned for PrivateMethod<'a> {
@@ -12553,15 +12499,9 @@ impl<'a> CastableNode<'a> for PrivateMethod<'a> {
 fn get_view_for_private_method<'a>(inner: &'a swc_ast::PrivateMethod, parent: Node<'a>, bump: &'a Bump) -> &'a PrivateMethod<'a> {
   let node = bump.alloc(PrivateMethod {
     inner,
-    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
-    kind: inner.kind,
-    is_static: inner.is_static,
-    accessibility: inner.accessibility,
-    is_abstract: inner.is_abstract,
-    is_optional: inner.is_optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_private_name(&inner.key, parent.clone(), bump);
@@ -12569,14 +12509,12 @@ fn get_view_for_private_method<'a>(inner: &'a swc_ast::PrivateMethod, parent: No
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializablePrivateName"))]
 pub struct PrivateName<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::PrivateName,
-  pub span: Span,
   pub id: &'a Ident<'a>,
 }
 
@@ -12629,7 +12567,6 @@ impl<'a> CastableNode<'a> for PrivateName<'a> {
 fn get_view_for_private_name<'a>(inner: &'a swc_ast::PrivateName, parent: Node<'a>, bump: &'a Bump) -> &'a PrivateName<'a> {
   let node = bump.alloc(PrivateName {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -12638,27 +12575,48 @@ fn get_view_for_private_name<'a>(inner: &'a swc_ast::PrivateName, parent: Node<'
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializablePrivateProp"))]
 pub struct PrivateProp<'a> {
-  #[serde(skip)]
   pub parent: &'a Class<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::PrivateProp,
-  pub span: Span,
   pub key: &'a PrivateName<'a>,
   pub value: Option<Expr<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub decorators: Vec<&'a Decorator<'a>>,
-  pub is_static: bool,
-  pub computed: bool,
+}
+
+impl<'a> PrivateProp<'a> {
+  pub fn is_static(&self) -> bool {
+    self.inner.is_static
+  }
+
+  pub fn computed(&self) -> bool {
+    self.inner.computed
+  }
+
   /// Typescript extension.
-  pub accessibility: Option<Accessibility>,
+  pub fn accessibility(&self) -> Option<Accessibility> {
+    self.inner.accessibility
+  }
+
   /// Typescript extension.
-  pub is_abstract: bool,
-  pub is_optional: bool,
-  pub readonly: bool,
-  pub definite: bool,
+  pub fn is_abstract(&self) -> bool {
+    self.inner.is_abstract
+  }
+
+  pub fn is_optional(&self) -> bool {
+    self.inner.is_optional
+  }
+
+  pub fn readonly(&self) -> bool {
+    self.inner.readonly
+  }
+
+  pub fn definite(&self) -> bool {
+    self.inner.definite
+  }
 }
 
 impl<'a> Spanned for PrivateProp<'a> {
@@ -12719,19 +12677,11 @@ impl<'a> CastableNode<'a> for PrivateProp<'a> {
 fn get_view_for_private_prop<'a>(inner: &'a swc_ast::PrivateProp, parent: Node<'a>, bump: &'a Bump) -> &'a PrivateProp<'a> {
   let node = bump.alloc(PrivateProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
     type_ann: None,
     decorators: Vec::with_capacity(inner.decorators.len()),
-    is_static: inner.is_static,
-    computed: inner.computed,
-    accessibility: inner.accessibility,
-    is_abstract: inner.is_abstract,
-    is_optional: inner.is_optional,
-    readonly: inner.readonly,
-    definite: inner.definite,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_private_name(&inner.key, parent.clone(), bump);
@@ -12747,16 +12697,22 @@ fn get_view_for_private_prop<'a>(inner: &'a swc_ast::PrivateProp, parent: Node<'
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableRegex"))]
 pub struct Regex<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Regex,
-  pub span: Span,
-  pub exp: &'a swc_atoms::JsWord,
-  pub flags: &'a swc_atoms::JsWord,
+}
+
+impl<'a> Regex<'a> {
+  pub fn exp(&self) -> &swc_atoms::JsWord {
+    &self.inner.exp
+  }
+
+  pub fn flags(&self) -> &swc_atoms::JsWord {
+    &self.inner.flags
+  }
 }
 
 impl<'a> Spanned for Regex<'a> {
@@ -12806,26 +12762,26 @@ impl<'a> CastableNode<'a> for Regex<'a> {
 fn get_view_for_regex<'a>(inner: &'a swc_ast::Regex, parent: Node<'a>, bump: &'a Bump) -> &'a Regex<'a> {
   let node = bump.alloc(Regex {
     inner,
-    span: inner.span(),
     parent,
-    exp: &inner.exp,
-    flags: &inner.flags,
   });
   node
 }
 
 /// EsTree `RestElement`
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableRestPat"))]
 pub struct RestPat<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::RestPat,
-  pub span: Span,
   pub arg: Pat<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-  pub dot3_token: &'a swc_common::Span,
+}
+
+impl<'a> RestPat<'a> {
+  pub fn dot3_token(&self) -> &swc_common::Span {
+    &self.inner.dot3_token
+  }
 }
 
 impl<'a> Spanned for RestPat<'a> {
@@ -12880,11 +12836,9 @@ impl<'a> CastableNode<'a> for RestPat<'a> {
 fn get_view_for_rest_pat<'a>(inner: &'a swc_ast::RestPat, parent: Node<'a>, bump: &'a Bump) -> &'a RestPat<'a> {
   let node = bump.alloc(RestPat {
     inner,
-    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
-    dot3_token: &inner.dot3_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = get_view_for_pat(&inner.arg, parent.clone(), bump);
@@ -12895,14 +12849,12 @@ fn get_view_for_rest_pat<'a>(inner: &'a swc_ast::RestPat, parent: Node<'a>, bump
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableReturnStmt"))]
 pub struct ReturnStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ReturnStmt,
-  pub span: Span,
   pub arg: Option<Expr<'a>>,
 }
 
@@ -12957,7 +12909,6 @@ impl<'a> CastableNode<'a> for ReturnStmt<'a> {
 fn get_view_for_return_stmt<'a>(inner: &'a swc_ast::ReturnStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ReturnStmt<'a> {
   let node = bump.alloc(ReturnStmt {
     inner,
-    span: inner.span(),
     parent,
     arg: None,
   });
@@ -12969,20 +12920,21 @@ fn get_view_for_return_stmt<'a>(inner: &'a swc_ast::ReturnStmt, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableScript"))]
 pub struct Script<'a> {
-  #[serde(skip)]
   pub source_file: Option<&'a swc_common::SourceFile>,
-  #[serde(skip)]
   pub tokens: Option<&'a TokenContainer<'a>>,
-  #[serde(skip)]
   pub comments: Option<&'a CommentContainer<'a>>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Script,
-  pub span: Span,
   pub body: Vec<Stmt<'a>>,
-  pub shebang: &'a Option<swc_atoms::JsWord>,
+}
+
+impl<'a> Script<'a> {
+  pub fn shebang(&self) -> &Option<swc_atoms::JsWord> {
+    &self.inner.shebang
+  }
 }
 
 impl<'a> Spanned for Script<'a> {
@@ -13043,26 +12995,22 @@ fn get_view_for_script<'a>(source_file_info: &'a ScriptInfo<'a>, bump: &'a Bump)
   )));
   let node = bump.alloc(Script {
     inner,
-    span: inner.span(),
     source_file: source_file_info.source_file,
     tokens,
     comments,
     body: Vec::with_capacity(inner.body.len()),
-    shebang: &inner.shebang,
   });
   let parent: Node<'a> = (&*node).into();
   node.body.extend(inner.body.iter().map(|value| get_view_for_stmt(value, parent.clone(), bump)));
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableSeqExpr"))]
 pub struct SeqExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::SeqExpr,
-  pub span: Span,
   pub exprs: Vec<Expr<'a>>,
 }
 
@@ -13117,7 +13065,6 @@ impl<'a> CastableNode<'a> for SeqExpr<'a> {
 fn get_view_for_seq_expr<'a>(inner: &'a swc_ast::SeqExpr, parent: Node<'a>, bump: &'a Bump) -> &'a SeqExpr<'a> {
   let node = bump.alloc(SeqExpr {
     inner,
-    span: inner.span(),
     parent,
     exprs: Vec::with_capacity(inner.exprs.len()),
   });
@@ -13126,14 +13073,12 @@ fn get_view_for_seq_expr<'a>(inner: &'a swc_ast::SeqExpr, parent: Node<'a>, bump
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableSetterProp"))]
 pub struct SetterProp<'a> {
-  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::SetterProp,
-  pub span: Span,
   pub key: PropName<'a>,
   pub param: Pat<'a>,
   pub body: Option<&'a BlockStmt<'a>>,
@@ -13192,7 +13137,6 @@ impl<'a> CastableNode<'a> for SetterProp<'a> {
 fn get_view_for_setter_prop<'a>(inner: &'a swc_ast::SetterProp, parent: Node<'a>, bump: &'a Bump) -> &'a SetterProp<'a> {
   let node = bump.alloc(SetterProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     param: unsafe { MaybeUninit::uninit().assume_init() },
@@ -13208,16 +13152,19 @@ fn get_view_for_setter_prop<'a>(inner: &'a swc_ast::SetterProp, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableSpreadElement"))]
 pub struct SpreadElement<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::SpreadElement,
-  pub span: Span,
   pub expr: Expr<'a>,
-  pub dot3_token: &'a swc_common::Span,
+}
+
+impl<'a> SpreadElement<'a> {
+  pub fn dot3_token(&self) -> &swc_common::Span {
+    &self.inner.dot3_token
+  }
 }
 
 impl<'a> Spanned for SpreadElement<'a> {
@@ -13269,28 +13216,35 @@ impl<'a> CastableNode<'a> for SpreadElement<'a> {
 fn get_view_for_spread_element<'a>(inner: &'a swc_ast::SpreadElement, parent: Node<'a>, bump: &'a Bump) -> &'a SpreadElement<'a> {
   let node = bump.alloc(SpreadElement {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
-    dot3_token: &inner.dot3_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.expr = get_view_for_expr(&inner.expr, parent, bump);
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableStr"))]
 pub struct Str<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Str,
-  pub span: Span,
-  pub value: &'a swc_atoms::JsWord,
+}
+
+impl<'a> Str<'a> {
+  pub fn value(&self) -> &swc_atoms::JsWord {
+    &self.inner.value
+  }
+
   /// This includes line escape.
-  pub has_escape: bool,
-  pub kind: StrKind,
+  pub fn has_escape(&self) -> bool {
+    self.inner.has_escape
+  }
+
+  pub fn kind(&self) -> StrKind {
+    self.inner.kind
+  }
 }
 
 impl<'a> Spanned for Str<'a> {
@@ -13340,23 +13294,17 @@ impl<'a> CastableNode<'a> for Str<'a> {
 fn get_view_for_str<'a>(inner: &'a swc_ast::Str, parent: Node<'a>, bump: &'a Bump) -> &'a Str<'a> {
   let node = bump.alloc(Str {
     inner,
-    span: inner.span(),
     parent,
-    value: &inner.value,
-    has_escape: inner.has_escape,
-    kind: inner.kind,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableSuper"))]
 pub struct Super<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Super,
-  pub span: Span,
 }
 
 impl<'a> Spanned for Super<'a> {
@@ -13406,20 +13354,17 @@ impl<'a> CastableNode<'a> for Super<'a> {
 fn get_view_for_super<'a>(inner: &'a swc_ast::Super, parent: Node<'a>, bump: &'a Bump) -> &'a Super<'a> {
   let node = bump.alloc(Super {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableSwitchCase"))]
 pub struct SwitchCase<'a> {
-  #[serde(skip)]
   pub parent: &'a SwitchStmt<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::SwitchCase,
-  pub span: Span,
   /// None for `default:`
   pub test: Option<Expr<'a>>,
   pub cons: Vec<Stmt<'a>>,
@@ -13479,7 +13424,6 @@ impl<'a> CastableNode<'a> for SwitchCase<'a> {
 fn get_view_for_switch_case<'a>(inner: &'a swc_ast::SwitchCase, parent: Node<'a>, bump: &'a Bump) -> &'a SwitchCase<'a> {
   let node = bump.alloc(SwitchCase {
     inner,
-    span: inner.span(),
     parent: parent.expect::<SwitchStmt>(),
     test: None,
     cons: Vec::with_capacity(inner.cons.len()),
@@ -13493,14 +13437,12 @@ fn get_view_for_switch_case<'a>(inner: &'a swc_ast::SwitchCase, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableSwitchStmt"))]
 pub struct SwitchStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::SwitchStmt,
-  pub span: Span,
   pub discriminant: Expr<'a>,
   pub cases: Vec<&'a SwitchCase<'a>>,
 }
@@ -13557,7 +13499,6 @@ impl<'a> CastableNode<'a> for SwitchStmt<'a> {
 fn get_view_for_switch_stmt<'a>(inner: &'a swc_ast::SwitchStmt, parent: Node<'a>, bump: &'a Bump) -> &'a SwitchStmt<'a> {
   let node = bump.alloc(SwitchStmt {
     inner,
-    span: inner.span(),
     parent,
     discriminant: unsafe { MaybeUninit::uninit().assume_init() },
     cases: Vec::with_capacity(inner.cases.len()),
@@ -13568,14 +13509,12 @@ fn get_view_for_switch_stmt<'a>(inner: &'a swc_ast::SwitchStmt, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTaggedTpl"))]
 pub struct TaggedTpl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TaggedTpl,
-  pub span: Span,
   pub tag: Expr<'a>,
   pub exprs: Vec<Expr<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
@@ -13640,7 +13579,6 @@ impl<'a> CastableNode<'a> for TaggedTpl<'a> {
 fn get_view_for_tagged_tpl<'a>(inner: &'a swc_ast::TaggedTpl, parent: Node<'a>, bump: &'a Bump) -> &'a TaggedTpl<'a> {
   let node = bump.alloc(TaggedTpl {
     inner,
-    span: inner.span(),
     parent,
     tag: unsafe { MaybeUninit::uninit().assume_init() },
     exprs: Vec::with_capacity(inner.exprs.len()),
@@ -13658,14 +13596,12 @@ fn get_view_for_tagged_tpl<'a>(inner: &'a swc_ast::TaggedTpl, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableThisExpr"))]
 pub struct ThisExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ThisExpr,
-  pub span: Span,
 }
 
 impl<'a> Spanned for ThisExpr<'a> {
@@ -13715,20 +13651,17 @@ impl<'a> CastableNode<'a> for ThisExpr<'a> {
 fn get_view_for_this_expr<'a>(inner: &'a swc_ast::ThisExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ThisExpr<'a> {
   let node = bump.alloc(ThisExpr {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableThrowStmt"))]
 pub struct ThrowStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::ThrowStmt,
-  pub span: Span,
   pub arg: Expr<'a>,
 }
 
@@ -13781,7 +13714,6 @@ impl<'a> CastableNode<'a> for ThrowStmt<'a> {
 fn get_view_for_throw_stmt<'a>(inner: &'a swc_ast::ThrowStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ThrowStmt<'a> {
   let node = bump.alloc(ThrowStmt {
     inner,
-    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -13790,14 +13722,12 @@ fn get_view_for_throw_stmt<'a>(inner: &'a swc_ast::ThrowStmt, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTpl"))]
 pub struct Tpl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::Tpl,
-  pub span: Span,
   pub exprs: Vec<Expr<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
 }
@@ -13856,7 +13786,6 @@ impl<'a> CastableNode<'a> for Tpl<'a> {
 fn get_view_for_tpl<'a>(inner: &'a swc_ast::Tpl, parent: Node<'a>, bump: &'a Bump) -> &'a Tpl<'a> {
   let node = bump.alloc(Tpl {
     inner,
-    span: inner.span(),
     parent,
     exprs: Vec::with_capacity(inner.exprs.len()),
     quasis: Vec::with_capacity(inner.quasis.len()),
@@ -13867,17 +13796,20 @@ fn get_view_for_tpl<'a>(inner: &'a swc_ast::Tpl, parent: Node<'a>, bump: &'a Bum
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTplElement"))]
 pub struct TplElement<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TplElement,
-  pub span: Span,
   pub cooked: Option<&'a Str<'a>>,
   pub raw: &'a Str<'a>,
-  pub tail: bool,
+}
+
+impl<'a> TplElement<'a> {
+  pub fn tail(&self) -> bool {
+    self.inner.tail
+  }
 }
 
 impl<'a> Spanned for TplElement<'a> {
@@ -13932,11 +13864,9 @@ impl<'a> CastableNode<'a> for TplElement<'a> {
 fn get_view_for_tpl_element<'a>(inner: &'a swc_ast::TplElement, parent: Node<'a>, bump: &'a Bump) -> &'a TplElement<'a> {
   let node = bump.alloc(TplElement {
     inner,
-    span: inner.span(),
     parent,
     cooked: None,
     raw: unsafe { MaybeUninit::uninit().assume_init() },
-    tail: inner.tail,
   });
   let parent: Node<'a> = (&*node).into();
   node.cooked = match &inner.cooked {
@@ -13947,14 +13877,12 @@ fn get_view_for_tpl_element<'a>(inner: &'a swc_ast::TplElement, parent: Node<'a>
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTryStmt"))]
 pub struct TryStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TryStmt,
-  pub span: Span,
   pub block: &'a BlockStmt<'a>,
   pub handler: Option<&'a CatchClause<'a>>,
   pub finalizer: Option<&'a BlockStmt<'a>>,
@@ -14015,7 +13943,6 @@ impl<'a> CastableNode<'a> for TryStmt<'a> {
 fn get_view_for_try_stmt<'a>(inner: &'a swc_ast::TryStmt, parent: Node<'a>, bump: &'a Bump) -> &'a TryStmt<'a> {
   let node = bump.alloc(TryStmt {
     inner,
-    span: inner.span(),
     parent,
     block: unsafe { MaybeUninit::uninit().assume_init() },
     handler: None,
@@ -14034,14 +13961,12 @@ fn get_view_for_try_stmt<'a>(inner: &'a swc_ast::TryStmt, parent: Node<'a>, bump
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsArrayType"))]
 pub struct TsArrayType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsArrayType,
-  pub span: Span,
   pub elem_type: TsType<'a>,
 }
 
@@ -14094,7 +14019,6 @@ impl<'a> CastableNode<'a> for TsArrayType<'a> {
 fn get_view_for_ts_array_type<'a>(inner: &'a swc_ast::TsArrayType, parent: Node<'a>, bump: &'a Bump) -> &'a TsArrayType<'a> {
   let node = bump.alloc(TsArrayType {
     inner,
-    span: inner.span(),
     parent,
     elem_type: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -14103,14 +14027,12 @@ fn get_view_for_ts_array_type<'a>(inner: &'a swc_ast::TsArrayType, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsAsExpr"))]
 pub struct TsAsExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsAsExpr,
-  pub span: Span,
   pub expr: Expr<'a>,
   pub type_ann: TsType<'a>,
 }
@@ -14165,7 +14087,6 @@ impl<'a> CastableNode<'a> for TsAsExpr<'a> {
 fn get_view_for_ts_as_expr<'a>(inner: &'a swc_ast::TsAsExpr, parent: Node<'a>, bump: &'a Bump) -> &'a TsAsExpr<'a> {
   let node = bump.alloc(TsAsExpr {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
@@ -14176,14 +14097,12 @@ fn get_view_for_ts_as_expr<'a>(inner: &'a swc_ast::TsAsExpr, parent: Node<'a>, b
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsCallSignatureDecl"))]
 pub struct TsCallSignatureDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsCallSignatureDecl,
-  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -14246,7 +14165,6 @@ impl<'a> CastableNode<'a> for TsCallSignatureDecl<'a> {
 fn get_view_for_ts_call_signature_decl<'a>(inner: &'a swc_ast::TsCallSignatureDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsCallSignatureDecl<'a> {
   let node = bump.alloc(TsCallSignatureDecl {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
@@ -14265,14 +14183,12 @@ fn get_view_for_ts_call_signature_decl<'a>(inner: &'a swc_ast::TsCallSignatureDe
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsConditionalType"))]
 pub struct TsConditionalType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsConditionalType,
-  pub span: Span,
   pub check_type: TsType<'a>,
   pub extends_type: TsType<'a>,
   pub true_type: TsType<'a>,
@@ -14331,7 +14247,6 @@ impl<'a> CastableNode<'a> for TsConditionalType<'a> {
 fn get_view_for_ts_conditional_type<'a>(inner: &'a swc_ast::TsConditionalType, parent: Node<'a>, bump: &'a Bump) -> &'a TsConditionalType<'a> {
   let node = bump.alloc(TsConditionalType {
     inner,
-    span: inner.span(),
     parent,
     check_type: unsafe { MaybeUninit::uninit().assume_init() },
     extends_type: unsafe { MaybeUninit::uninit().assume_init() },
@@ -14346,14 +14261,12 @@ fn get_view_for_ts_conditional_type<'a>(inner: &'a swc_ast::TsConditionalType, p
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsConstAssertion"))]
 pub struct TsConstAssertion<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsConstAssertion,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -14406,7 +14319,6 @@ impl<'a> CastableNode<'a> for TsConstAssertion<'a> {
 fn get_view_for_ts_const_assertion<'a>(inner: &'a swc_ast::TsConstAssertion, parent: Node<'a>, bump: &'a Bump) -> &'a TsConstAssertion<'a> {
   let node = bump.alloc(TsConstAssertion {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -14415,14 +14327,12 @@ fn get_view_for_ts_const_assertion<'a>(inner: &'a swc_ast::TsConstAssertion, par
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsConstructSignatureDecl"))]
 pub struct TsConstructSignatureDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsConstructSignatureDecl,
-  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -14485,7 +14395,6 @@ impl<'a> CastableNode<'a> for TsConstructSignatureDecl<'a> {
 fn get_view_for_ts_construct_signature_decl<'a>(inner: &'a swc_ast::TsConstructSignatureDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsConstructSignatureDecl<'a> {
   let node = bump.alloc(TsConstructSignatureDecl {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
@@ -14504,18 +14413,21 @@ fn get_view_for_ts_construct_signature_decl<'a>(inner: &'a swc_ast::TsConstructS
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsConstructorType"))]
 pub struct TsConstructorType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsConstructorType,
-  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: &'a TsTypeAnn<'a>,
-  pub is_abstract: bool,
+}
+
+impl<'a> TsConstructorType<'a> {
+  pub fn is_abstract(&self) -> bool {
+    self.inner.is_abstract
+  }
 }
 
 impl<'a> Spanned for TsConstructorType<'a> {
@@ -14573,12 +14485,10 @@ impl<'a> CastableNode<'a> for TsConstructorType<'a> {
 fn get_view_for_ts_constructor_type<'a>(inner: &'a swc_ast::TsConstructorType, parent: Node<'a>, bump: &'a Bump) -> &'a TsConstructorType<'a> {
   let node = bump.alloc(TsConstructorType {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_params: None,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
-    is_abstract: inner.is_abstract,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_ts_fn_param(value, parent.clone(), bump)));
@@ -14590,18 +14500,24 @@ fn get_view_for_ts_constructor_type<'a>(inner: &'a swc_ast::TsConstructorType, p
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsEnumDecl"))]
 pub struct TsEnumDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsEnumDecl,
-  pub span: Span,
   pub id: &'a Ident<'a>,
   pub members: Vec<&'a TsEnumMember<'a>>,
-  pub declare: bool,
-  pub is_const: bool,
+}
+
+impl<'a> TsEnumDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
+
+  pub fn is_const(&self) -> bool {
+    self.inner.is_const
+  }
 }
 
 impl<'a> Spanned for TsEnumDecl<'a> {
@@ -14656,12 +14572,9 @@ impl<'a> CastableNode<'a> for TsEnumDecl<'a> {
 fn get_view_for_ts_enum_decl<'a>(inner: &'a swc_ast::TsEnumDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsEnumDecl<'a> {
   let node = bump.alloc(TsEnumDecl {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     members: Vec::with_capacity(inner.members.len()),
-    declare: inner.declare,
-    is_const: inner.is_const,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -14669,14 +14582,12 @@ fn get_view_for_ts_enum_decl<'a>(inner: &'a swc_ast::TsEnumDecl, parent: Node<'a
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsEnumMember"))]
 pub struct TsEnumMember<'a> {
-  #[serde(skip)]
   pub parent: &'a TsEnumDecl<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsEnumMember,
-  pub span: Span,
   pub id: TsEnumMemberId<'a>,
   pub init: Option<Expr<'a>>,
 }
@@ -14733,7 +14644,6 @@ impl<'a> CastableNode<'a> for TsEnumMember<'a> {
 fn get_view_for_ts_enum_member<'a>(inner: &'a swc_ast::TsEnumMember, parent: Node<'a>, bump: &'a Bump) -> &'a TsEnumMember<'a> {
   let node = bump.alloc(TsEnumMember {
     inner,
-    span: inner.span(),
     parent: parent.expect::<TsEnumDecl>(),
     id: unsafe { MaybeUninit::uninit().assume_init() },
     init: None,
@@ -14750,14 +14660,12 @@ fn get_view_for_ts_enum_member<'a>(inner: &'a swc_ast::TsEnumMember, parent: Nod
 /// TypeScript's own parser uses ExportAssignment for both `export default` and
 /// `export =`. But for @babel/parser, `export default` is an ExportDefaultDecl,
 /// so a TsExportAssignment is always `export =`.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsExportAssignment"))]
 pub struct TsExportAssignment<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsExportAssignment,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -14810,7 +14718,6 @@ impl<'a> CastableNode<'a> for TsExportAssignment<'a> {
 fn get_view_for_ts_export_assignment<'a>(inner: &'a swc_ast::TsExportAssignment, parent: Node<'a>, bump: &'a Bump) -> &'a TsExportAssignment<'a> {
   let node = bump.alloc(TsExportAssignment {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -14819,14 +14726,12 @@ fn get_view_for_ts_export_assignment<'a>(inner: &'a swc_ast::TsExportAssignment,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsExprWithTypeArgs"))]
 pub struct TsExprWithTypeArgs<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsExprWithTypeArgs,
-  pub span: Span,
   pub expr: TsEntityName<'a>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
 }
@@ -14883,7 +14788,6 @@ impl<'a> CastableNode<'a> for TsExprWithTypeArgs<'a> {
 fn get_view_for_ts_expr_with_type_args<'a>(inner: &'a swc_ast::TsExprWithTypeArgs, parent: Node<'a>, bump: &'a Bump) -> &'a TsExprWithTypeArgs<'a> {
   let node = bump.alloc(TsExprWithTypeArgs {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     type_args: None,
@@ -14897,14 +14801,12 @@ fn get_view_for_ts_expr_with_type_args<'a>(inner: &'a swc_ast::TsExprWithTypeArg
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsExternalModuleRef"))]
 pub struct TsExternalModuleRef<'a> {
-  #[serde(skip)]
   pub parent: &'a TsImportEqualsDecl<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsExternalModuleRef,
-  pub span: Span,
   pub expr: &'a Str<'a>,
 }
 
@@ -14957,7 +14859,6 @@ impl<'a> CastableNode<'a> for TsExternalModuleRef<'a> {
 fn get_view_for_ts_external_module_ref<'a>(inner: &'a swc_ast::TsExternalModuleRef, parent: Node<'a>, bump: &'a Bump) -> &'a TsExternalModuleRef<'a> {
   let node = bump.alloc(TsExternalModuleRef {
     inner,
-    span: inner.span(),
     parent: parent.expect::<TsImportEqualsDecl>(),
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -14966,14 +14867,12 @@ fn get_view_for_ts_external_module_ref<'a>(inner: &'a swc_ast::TsExternalModuleR
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsFnType"))]
 pub struct TsFnType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsFnType,
-  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: &'a TsTypeAnn<'a>,
@@ -15034,7 +14933,6 @@ impl<'a> CastableNode<'a> for TsFnType<'a> {
 fn get_view_for_ts_fn_type<'a>(inner: &'a swc_ast::TsFnType, parent: Node<'a>, bump: &'a Bump) -> &'a TsFnType<'a> {
   let node = bump.alloc(TsFnType {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_params: None,
@@ -15050,18 +14948,24 @@ fn get_view_for_ts_fn_type<'a>(inner: &'a swc_ast::TsFnType, parent: Node<'a>, b
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsImportEqualsDecl"))]
 pub struct TsImportEqualsDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsImportEqualsDecl,
-  pub span: Span,
   pub id: &'a Ident<'a>,
   pub module_ref: TsModuleRef<'a>,
-  pub declare: bool,
-  pub is_export: bool,
+}
+
+impl<'a> TsImportEqualsDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
+
+  pub fn is_export(&self) -> bool {
+    self.inner.is_export
+  }
 }
 
 impl<'a> Spanned for TsImportEqualsDecl<'a> {
@@ -15114,12 +15018,9 @@ impl<'a> CastableNode<'a> for TsImportEqualsDecl<'a> {
 fn get_view_for_ts_import_equals_decl<'a>(inner: &'a swc_ast::TsImportEqualsDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsImportEqualsDecl<'a> {
   let node = bump.alloc(TsImportEqualsDecl {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     module_ref: unsafe { MaybeUninit::uninit().assume_init() },
-    declare: inner.declare,
-    is_export: inner.is_export,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -15127,14 +15028,12 @@ fn get_view_for_ts_import_equals_decl<'a>(inner: &'a swc_ast::TsImportEqualsDecl
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsImportType"))]
 pub struct TsImportType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsImportType,
-  pub span: Span,
   pub arg: &'a Str<'a>,
   pub qualifier: Option<TsEntityName<'a>>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -15195,7 +15094,6 @@ impl<'a> CastableNode<'a> for TsImportType<'a> {
 fn get_view_for_ts_import_type<'a>(inner: &'a swc_ast::TsImportType, parent: Node<'a>, bump: &'a Bump) -> &'a TsImportType<'a> {
   let node = bump.alloc(TsImportType {
     inner,
-    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
     qualifier: None,
@@ -15214,17 +15112,20 @@ fn get_view_for_ts_import_type<'a>(inner: &'a swc_ast::TsImportType, parent: Nod
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsIndexSignature"))]
 pub struct TsIndexSignature<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsIndexSignature,
-  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-  pub readonly: bool,
+}
+
+impl<'a> TsIndexSignature<'a> {
+  pub fn readonly(&self) -> bool {
+    self.inner.readonly
+  }
 }
 
 impl<'a> Spanned for TsIndexSignature<'a> {
@@ -15281,11 +15182,9 @@ impl<'a> CastableNode<'a> for TsIndexSignature<'a> {
 fn get_view_for_ts_index_signature<'a>(inner: &'a swc_ast::TsIndexSignature, parent: Node<'a>, bump: &'a Bump) -> &'a TsIndexSignature<'a> {
   let node = bump.alloc(TsIndexSignature {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
-    readonly: inner.readonly,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_ts_fn_param(value, parent.clone(), bump)));
@@ -15296,17 +15195,20 @@ fn get_view_for_ts_index_signature<'a>(inner: &'a swc_ast::TsIndexSignature, par
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsIndexedAccessType"))]
 pub struct TsIndexedAccessType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsIndexedAccessType,
-  pub span: Span,
   pub obj_type: TsType<'a>,
   pub index_type: TsType<'a>,
-  pub readonly: bool,
+}
+
+impl<'a> TsIndexedAccessType<'a> {
+  pub fn readonly(&self) -> bool {
+    self.inner.readonly
+  }
 }
 
 impl<'a> Spanned for TsIndexedAccessType<'a> {
@@ -15359,11 +15261,9 @@ impl<'a> CastableNode<'a> for TsIndexedAccessType<'a> {
 fn get_view_for_ts_indexed_access_type<'a>(inner: &'a swc_ast::TsIndexedAccessType, parent: Node<'a>, bump: &'a Bump) -> &'a TsIndexedAccessType<'a> {
   let node = bump.alloc(TsIndexedAccessType {
     inner,
-    span: inner.span(),
     parent,
     obj_type: unsafe { MaybeUninit::uninit().assume_init() },
     index_type: unsafe { MaybeUninit::uninit().assume_init() },
-    readonly: inner.readonly,
   });
   let parent: Node<'a> = (&*node).into();
   node.obj_type = get_view_for_ts_type(&inner.obj_type, parent.clone(), bump);
@@ -15371,14 +15271,12 @@ fn get_view_for_ts_indexed_access_type<'a>(inner: &'a swc_ast::TsIndexedAccessTy
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsInferType"))]
 pub struct TsInferType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsInferType,
-  pub span: Span,
   pub type_param: &'a TsTypeParam<'a>,
 }
 
@@ -15431,7 +15329,6 @@ impl<'a> CastableNode<'a> for TsInferType<'a> {
 fn get_view_for_ts_infer_type<'a>(inner: &'a swc_ast::TsInferType, parent: Node<'a>, bump: &'a Bump) -> &'a TsInferType<'a> {
   let node = bump.alloc(TsInferType {
     inner,
-    span: inner.span(),
     parent,
     type_param: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -15440,14 +15337,12 @@ fn get_view_for_ts_infer_type<'a>(inner: &'a swc_ast::TsInferType, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsInterfaceBody"))]
 pub struct TsInterfaceBody<'a> {
-  #[serde(skip)]
   pub parent: &'a TsInterfaceDecl<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsInterfaceBody,
-  pub span: Span,
   pub body: Vec<TsTypeElement<'a>>,
 }
 
@@ -15502,7 +15397,6 @@ impl<'a> CastableNode<'a> for TsInterfaceBody<'a> {
 fn get_view_for_ts_interface_body<'a>(inner: &'a swc_ast::TsInterfaceBody, parent: Node<'a>, bump: &'a Bump) -> &'a TsInterfaceBody<'a> {
   let node = bump.alloc(TsInterfaceBody {
     inner,
-    span: inner.span(),
     parent: parent.expect::<TsInterfaceDecl>(),
     body: Vec::with_capacity(inner.body.len()),
   });
@@ -15511,19 +15405,22 @@ fn get_view_for_ts_interface_body<'a>(inner: &'a swc_ast::TsInterfaceBody, paren
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsInterfaceDecl"))]
 pub struct TsInterfaceDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsInterfaceDecl,
-  pub span: Span,
   pub id: &'a Ident<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub extends: Vec<&'a TsExprWithTypeArgs<'a>>,
   pub body: &'a TsInterfaceBody<'a>,
-  pub declare: bool,
+}
+
+impl<'a> TsInterfaceDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
 }
 
 impl<'a> Spanned for TsInterfaceDecl<'a> {
@@ -15582,13 +15479,11 @@ impl<'a> CastableNode<'a> for TsInterfaceDecl<'a> {
 fn get_view_for_ts_interface_decl<'a>(inner: &'a swc_ast::TsInterfaceDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsInterfaceDecl<'a> {
   let node = bump.alloc(TsInterfaceDecl {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
     extends: Vec::with_capacity(inner.extends.len()),
     body: unsafe { MaybeUninit::uninit().assume_init() },
-    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -15601,14 +15496,12 @@ fn get_view_for_ts_interface_decl<'a>(inner: &'a swc_ast::TsInterfaceDecl, paren
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsIntersectionType"))]
 pub struct TsIntersectionType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsIntersectionType,
-  pub span: Span,
   pub types: Vec<TsType<'a>>,
 }
 
@@ -15663,7 +15556,6 @@ impl<'a> CastableNode<'a> for TsIntersectionType<'a> {
 fn get_view_for_ts_intersection_type<'a>(inner: &'a swc_ast::TsIntersectionType, parent: Node<'a>, bump: &'a Bump) -> &'a TsIntersectionType<'a> {
   let node = bump.alloc(TsIntersectionType {
     inner,
-    span: inner.span(),
     parent,
     types: Vec::with_capacity(inner.types.len()),
   });
@@ -15672,15 +15564,18 @@ fn get_view_for_ts_intersection_type<'a>(inner: &'a swc_ast::TsIntersectionType,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsKeywordType"))]
 pub struct TsKeywordType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsKeywordType,
-  pub span: Span,
-  pub kind: TsKeywordTypeKind,
+}
+
+impl<'a> TsKeywordType<'a> {
+  pub fn kind(&self) -> TsKeywordTypeKind {
+    self.inner.kind
+  }
 }
 
 impl<'a> Spanned for TsKeywordType<'a> {
@@ -15730,21 +15625,17 @@ impl<'a> CastableNode<'a> for TsKeywordType<'a> {
 fn get_view_for_ts_keyword_type<'a>(inner: &'a swc_ast::TsKeywordType, parent: Node<'a>, bump: &'a Bump) -> &'a TsKeywordType<'a> {
   let node = bump.alloc(TsKeywordType {
     inner,
-    span: inner.span(),
     parent,
-    kind: inner.kind,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsLitType"))]
 pub struct TsLitType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsLitType,
-  pub span: Span,
   pub lit: TsLit<'a>,
 }
 
@@ -15797,7 +15688,6 @@ impl<'a> CastableNode<'a> for TsLitType<'a> {
 fn get_view_for_ts_lit_type<'a>(inner: &'a swc_ast::TsLitType, parent: Node<'a>, bump: &'a Bump) -> &'a TsLitType<'a> {
   let node = bump.alloc(TsLitType {
     inner,
-    span: inner.span(),
     parent,
     lit: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -15806,19 +15696,25 @@ fn get_view_for_ts_lit_type<'a>(inner: &'a swc_ast::TsLitType, parent: Node<'a>,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsMappedType"))]
 pub struct TsMappedType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsMappedType,
-  pub span: Span,
   pub type_param: &'a TsTypeParam<'a>,
   pub name_type: Option<TsType<'a>>,
   pub type_ann: Option<TsType<'a>>,
-  pub readonly: Option<TruePlusMinus>,
-  pub optional: Option<TruePlusMinus>,
+}
+
+impl<'a> TsMappedType<'a> {
+  pub fn readonly(&self) -> Option<TruePlusMinus> {
+    self.inner.readonly
+  }
+
+  pub fn optional(&self) -> Option<TruePlusMinus> {
+    self.inner.optional
+  }
 }
 
 impl<'a> Spanned for TsMappedType<'a> {
@@ -15876,13 +15772,10 @@ impl<'a> CastableNode<'a> for TsMappedType<'a> {
 fn get_view_for_ts_mapped_type<'a>(inner: &'a swc_ast::TsMappedType, parent: Node<'a>, bump: &'a Bump) -> &'a TsMappedType<'a> {
   let node = bump.alloc(TsMappedType {
     inner,
-    span: inner.span(),
     parent,
     type_param: unsafe { MaybeUninit::uninit().assume_init() },
     name_type: None,
     type_ann: None,
-    readonly: inner.readonly,
-    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.type_param = get_view_for_ts_type_param(&inner.type_param, parent.clone(), bump);
@@ -15897,21 +15790,30 @@ fn get_view_for_ts_mapped_type<'a>(inner: &'a swc_ast::TsMappedType, parent: Nod
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsMethodSignature"))]
 pub struct TsMethodSignature<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsMethodSignature,
-  pub span: Span,
   pub key: Expr<'a>,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
-  pub readonly: bool,
-  pub computed: bool,
-  pub optional: bool,
+}
+
+impl<'a> TsMethodSignature<'a> {
+  pub fn readonly(&self) -> bool {
+    self.inner.readonly
+  }
+
+  pub fn computed(&self) -> bool {
+    self.inner.computed
+  }
+
+  pub fn optional(&self) -> bool {
+    self.inner.optional
+  }
 }
 
 impl<'a> Spanned for TsMethodSignature<'a> {
@@ -15972,15 +15874,11 @@ impl<'a> CastableNode<'a> for TsMethodSignature<'a> {
 fn get_view_for_ts_method_signature<'a>(inner: &'a swc_ast::TsMethodSignature, parent: Node<'a>, bump: &'a Bump) -> &'a TsMethodSignature<'a> {
   let node = bump.alloc(TsMethodSignature {
     inner,
-    span: inner.span(),
     parent,
     key: unsafe { MaybeUninit::uninit().assume_init() },
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
     type_params: None,
-    readonly: inner.readonly,
-    computed: inner.computed,
-    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_expr(&inner.key, parent.clone(), bump);
@@ -15996,14 +15894,12 @@ fn get_view_for_ts_method_signature<'a>(inner: &'a swc_ast::TsMethodSignature, p
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsModuleBlock"))]
 pub struct TsModuleBlock<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsModuleBlock,
-  pub span: Span,
   pub body: Vec<ModuleItem<'a>>,
 }
 
@@ -16058,7 +15954,6 @@ impl<'a> CastableNode<'a> for TsModuleBlock<'a> {
 fn get_view_for_ts_module_block<'a>(inner: &'a swc_ast::TsModuleBlock, parent: Node<'a>, bump: &'a Bump) -> &'a TsModuleBlock<'a> {
   let node = bump.alloc(TsModuleBlock {
     inner,
-    span: inner.span(),
     parent,
     body: Vec::with_capacity(inner.body.len()),
   });
@@ -16067,19 +15962,25 @@ fn get_view_for_ts_module_block<'a>(inner: &'a swc_ast::TsModuleBlock, parent: N
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsModuleDecl"))]
 pub struct TsModuleDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsModuleDecl,
-  pub span: Span,
   pub id: TsModuleName<'a>,
   pub body: Option<TsNamespaceBody<'a>>,
-  pub declare: bool,
+}
+
+impl<'a> TsModuleDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
+
   /// In TypeScript, this is only available through`node.flags`.
-  pub global: bool,
+  pub fn global(&self) -> bool {
+    self.inner.global
+  }
 }
 
 impl<'a> Spanned for TsModuleDecl<'a> {
@@ -16134,12 +16035,9 @@ impl<'a> CastableNode<'a> for TsModuleDecl<'a> {
 fn get_view_for_ts_module_decl<'a>(inner: &'a swc_ast::TsModuleDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsModuleDecl<'a> {
   let node = bump.alloc(TsModuleDecl {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     body: None,
-    declare: inner.declare,
-    global: inner.global,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ts_module_name(&inner.id, parent.clone(), bump);
@@ -16150,19 +16048,25 @@ fn get_view_for_ts_module_decl<'a>(inner: &'a swc_ast::TsModuleDecl, parent: Nod
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsNamespaceDecl"))]
 pub struct TsNamespaceDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsNamespaceDecl,
-  pub span: Span,
   pub id: &'a Ident<'a>,
   pub body: TsNamespaceBody<'a>,
-  pub declare: bool,
+}
+
+impl<'a> TsNamespaceDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
+
   /// In TypeScript, this is only available through`node.flags`.
-  pub global: bool,
+  pub fn global(&self) -> bool {
+    self.inner.global
+  }
 }
 
 impl<'a> Spanned for TsNamespaceDecl<'a> {
@@ -16215,12 +16119,9 @@ impl<'a> CastableNode<'a> for TsNamespaceDecl<'a> {
 fn get_view_for_ts_namespace_decl<'a>(inner: &'a swc_ast::TsNamespaceDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsNamespaceDecl<'a> {
   let node = bump.alloc(TsNamespaceDecl {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
-    declare: inner.declare,
-    global: inner.global,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -16228,14 +16129,12 @@ fn get_view_for_ts_namespace_decl<'a>(inner: &'a swc_ast::TsNamespaceDecl, paren
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsNamespaceExportDecl"))]
 pub struct TsNamespaceExportDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsNamespaceExportDecl,
-  pub span: Span,
   pub id: &'a Ident<'a>,
 }
 
@@ -16288,7 +16187,6 @@ impl<'a> CastableNode<'a> for TsNamespaceExportDecl<'a> {
 fn get_view_for_ts_namespace_export_decl<'a>(inner: &'a swc_ast::TsNamespaceExportDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsNamespaceExportDecl<'a> {
   let node = bump.alloc(TsNamespaceExportDecl {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16297,14 +16195,12 @@ fn get_view_for_ts_namespace_export_decl<'a>(inner: &'a swc_ast::TsNamespaceExpo
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsNonNullExpr"))]
 pub struct TsNonNullExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsNonNullExpr,
-  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -16357,7 +16253,6 @@ impl<'a> CastableNode<'a> for TsNonNullExpr<'a> {
 fn get_view_for_ts_non_null_expr<'a>(inner: &'a swc_ast::TsNonNullExpr, parent: Node<'a>, bump: &'a Bump) -> &'a TsNonNullExpr<'a> {
   let node = bump.alloc(TsNonNullExpr {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16366,14 +16261,12 @@ fn get_view_for_ts_non_null_expr<'a>(inner: &'a swc_ast::TsNonNullExpr, parent: 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsOptionalType"))]
 pub struct TsOptionalType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsOptionalType,
-  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -16426,7 +16319,6 @@ impl<'a> CastableNode<'a> for TsOptionalType<'a> {
 fn get_view_for_ts_optional_type<'a>(inner: &'a swc_ast::TsOptionalType, parent: Node<'a>, bump: &'a Bump) -> &'a TsOptionalType<'a> {
   let node = bump.alloc(TsOptionalType {
     inner,
-    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16435,19 +16327,25 @@ fn get_view_for_ts_optional_type<'a>(inner: &'a swc_ast::TsOptionalType, parent:
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsParamProp"))]
 pub struct TsParamProp<'a> {
-  #[serde(skip)]
   pub parent: &'a Constructor<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsParamProp,
-  pub span: Span,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub param: TsParamPropParam<'a>,
+}
+
+impl<'a> TsParamProp<'a> {
   /// At least one of `accessibility` or `readonly` must be set.
-  pub accessibility: Option<Accessibility>,
-  pub readonly: bool,
+  pub fn accessibility(&self) -> Option<Accessibility> {
+    self.inner.accessibility
+  }
+
+  pub fn readonly(&self) -> bool {
+    self.inner.readonly
+  }
 }
 
 impl<'a> Spanned for TsParamProp<'a> {
@@ -16502,12 +16400,9 @@ impl<'a> CastableNode<'a> for TsParamProp<'a> {
 fn get_view_for_ts_param_prop<'a>(inner: &'a swc_ast::TsParamProp, parent: Node<'a>, bump: &'a Bump) -> &'a TsParamProp<'a> {
   let node = bump.alloc(TsParamProp {
     inner,
-    span: inner.span(),
     parent: parent.expect::<Constructor>(),
     decorators: Vec::with_capacity(inner.decorators.len()),
     param: unsafe { MaybeUninit::uninit().assume_init() },
-    accessibility: inner.accessibility,
-    readonly: inner.readonly,
   });
   let parent: Node<'a> = (&*node).into();
   node.decorators.extend(inner.decorators.iter().map(|value| get_view_for_decorator(value, parent.clone(), bump)));
@@ -16515,14 +16410,12 @@ fn get_view_for_ts_param_prop<'a>(inner: &'a swc_ast::TsParamProp, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsParenthesizedType"))]
 pub struct TsParenthesizedType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsParenthesizedType,
-  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -16575,7 +16468,6 @@ impl<'a> CastableNode<'a> for TsParenthesizedType<'a> {
 fn get_view_for_ts_parenthesized_type<'a>(inner: &'a swc_ast::TsParenthesizedType, parent: Node<'a>, bump: &'a Bump) -> &'a TsParenthesizedType<'a> {
   let node = bump.alloc(TsParenthesizedType {
     inner,
-    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16584,22 +16476,31 @@ fn get_view_for_ts_parenthesized_type<'a>(inner: &'a swc_ast::TsParenthesizedTyp
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsPropertySignature"))]
 pub struct TsPropertySignature<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsPropertySignature,
-  pub span: Span,
   pub key: Expr<'a>,
   pub init: Option<Expr<'a>>,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
-  pub readonly: bool,
-  pub computed: bool,
-  pub optional: bool,
+}
+
+impl<'a> TsPropertySignature<'a> {
+  pub fn readonly(&self) -> bool {
+    self.inner.readonly
+  }
+
+  pub fn computed(&self) -> bool {
+    self.inner.computed
+  }
+
+  pub fn optional(&self) -> bool {
+    self.inner.optional
+  }
 }
 
 impl<'a> Spanned for TsPropertySignature<'a> {
@@ -16663,16 +16564,12 @@ impl<'a> CastableNode<'a> for TsPropertySignature<'a> {
 fn get_view_for_ts_property_signature<'a>(inner: &'a swc_ast::TsPropertySignature, parent: Node<'a>, bump: &'a Bump) -> &'a TsPropertySignature<'a> {
   let node = bump.alloc(TsPropertySignature {
     inner,
-    span: inner.span(),
     parent,
     key: unsafe { MaybeUninit::uninit().assume_init() },
     init: None,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
     type_params: None,
-    readonly: inner.readonly,
-    computed: inner.computed,
-    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_expr(&inner.key, parent.clone(), bump);
@@ -16692,14 +16589,12 @@ fn get_view_for_ts_property_signature<'a>(inner: &'a swc_ast::TsPropertySignatur
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsQualifiedName"))]
 pub struct TsQualifiedName<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsQualifiedName,
-  pub span: Span,
   pub left: TsEntityName<'a>,
   pub right: &'a Ident<'a>,
 }
@@ -16754,7 +16649,6 @@ impl<'a> CastableNode<'a> for TsQualifiedName<'a> {
 fn get_view_for_ts_qualified_name<'a>(inner: &'a swc_ast::TsQualifiedName, parent: Node<'a>, bump: &'a Bump) -> &'a TsQualifiedName<'a> {
   let node = bump.alloc(TsQualifiedName {
     inner,
-    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -16765,14 +16659,12 @@ fn get_view_for_ts_qualified_name<'a>(inner: &'a swc_ast::TsQualifiedName, paren
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsRestType"))]
 pub struct TsRestType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsRestType,
-  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -16825,7 +16717,6 @@ impl<'a> CastableNode<'a> for TsRestType<'a> {
 fn get_view_for_ts_rest_type<'a>(inner: &'a swc_ast::TsRestType, parent: Node<'a>, bump: &'a Bump) -> &'a TsRestType<'a> {
   let node = bump.alloc(TsRestType {
     inner,
-    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16834,14 +16725,12 @@ fn get_view_for_ts_rest_type<'a>(inner: &'a swc_ast::TsRestType, parent: Node<'a
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsThisType"))]
 pub struct TsThisType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsThisType,
-  pub span: Span,
 }
 
 impl<'a> Spanned for TsThisType<'a> {
@@ -16891,20 +16780,17 @@ impl<'a> CastableNode<'a> for TsThisType<'a> {
 fn get_view_for_ts_this_type<'a>(inner: &'a swc_ast::TsThisType, parent: Node<'a>, bump: &'a Bump) -> &'a TsThisType<'a> {
   let node = bump.alloc(TsThisType {
     inner,
-    span: inner.span(),
     parent,
   });
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTplLitType"))]
 pub struct TsTplLitType<'a> {
-  #[serde(skip)]
   pub parent: &'a TsLitType<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTplLitType,
-  pub span: Span,
   pub types: Vec<TsType<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
 }
@@ -16963,7 +16849,6 @@ impl<'a> CastableNode<'a> for TsTplLitType<'a> {
 fn get_view_for_ts_tpl_lit_type<'a>(inner: &'a swc_ast::TsTplLitType, parent: Node<'a>, bump: &'a Bump) -> &'a TsTplLitType<'a> {
   let node = bump.alloc(TsTplLitType {
     inner,
-    span: inner.span(),
     parent: parent.expect::<TsLitType>(),
     types: Vec::with_capacity(inner.types.len()),
     quasis: Vec::with_capacity(inner.quasis.len()),
@@ -16974,14 +16859,12 @@ fn get_view_for_ts_tpl_lit_type<'a>(inner: &'a swc_ast::TsTplLitType, parent: No
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTupleElement"))]
 pub struct TsTupleElement<'a> {
-  #[serde(skip)]
   pub parent: &'a TsTupleType<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTupleElement,
-  pub span: Span,
   /// `Ident` or `RestPat { arg: Ident }`
   pub label: Option<Pat<'a>>,
   pub ty: TsType<'a>,
@@ -17039,7 +16922,6 @@ impl<'a> CastableNode<'a> for TsTupleElement<'a> {
 fn get_view_for_ts_tuple_element<'a>(inner: &'a swc_ast::TsTupleElement, parent: Node<'a>, bump: &'a Bump) -> &'a TsTupleElement<'a> {
   let node = bump.alloc(TsTupleElement {
     inner,
-    span: inner.span(),
     parent: parent.expect::<TsTupleType>(),
     label: None,
     ty: unsafe { MaybeUninit::uninit().assume_init() },
@@ -17053,14 +16935,12 @@ fn get_view_for_ts_tuple_element<'a>(inner: &'a swc_ast::TsTupleElement, parent:
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTupleType"))]
 pub struct TsTupleType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTupleType,
-  pub span: Span,
   pub elem_types: Vec<&'a TsTupleElement<'a>>,
 }
 
@@ -17115,7 +16995,6 @@ impl<'a> CastableNode<'a> for TsTupleType<'a> {
 fn get_view_for_ts_tuple_type<'a>(inner: &'a swc_ast::TsTupleType, parent: Node<'a>, bump: &'a Bump) -> &'a TsTupleType<'a> {
   let node = bump.alloc(TsTupleType {
     inner,
-    span: inner.span(),
     parent,
     elem_types: Vec::with_capacity(inner.elem_types.len()),
   });
@@ -17124,18 +17003,21 @@ fn get_view_for_ts_tuple_type<'a>(inner: &'a swc_ast::TsTupleType, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeAliasDecl"))]
 pub struct TsTypeAliasDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAliasDecl,
-  pub span: Span,
   pub id: &'a Ident<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: TsType<'a>,
-  pub declare: bool,
+}
+
+impl<'a> TsTypeAliasDecl<'a> {
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
 }
 
 impl<'a> Spanned for TsTypeAliasDecl<'a> {
@@ -17191,12 +17073,10 @@ impl<'a> CastableNode<'a> for TsTypeAliasDecl<'a> {
 fn get_view_for_ts_type_alias_decl<'a>(inner: &'a swc_ast::TsTypeAliasDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeAliasDecl<'a> {
   let node = bump.alloc(TsTypeAliasDecl {
     inner,
-    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
-    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -17208,14 +17088,12 @@ fn get_view_for_ts_type_alias_decl<'a>(inner: &'a swc_ast::TsTypeAliasDecl, pare
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeAnn"))]
 pub struct TsTypeAnn<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAnn,
-  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -17268,7 +17146,6 @@ impl<'a> CastableNode<'a> for TsTypeAnn<'a> {
 fn get_view_for_ts_type_ann<'a>(inner: &'a swc_ast::TsTypeAnn, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeAnn<'a> {
   let node = bump.alloc(TsTypeAnn {
     inner,
-    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -17277,14 +17154,12 @@ fn get_view_for_ts_type_ann<'a>(inner: &'a swc_ast::TsTypeAnn, parent: Node<'a>,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeAssertion"))]
 pub struct TsTypeAssertion<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAssertion,
-  pub span: Span,
   pub expr: Expr<'a>,
   pub type_ann: TsType<'a>,
 }
@@ -17339,7 +17214,6 @@ impl<'a> CastableNode<'a> for TsTypeAssertion<'a> {
 fn get_view_for_ts_type_assertion<'a>(inner: &'a swc_ast::TsTypeAssertion, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeAssertion<'a> {
   let node = bump.alloc(TsTypeAssertion {
     inner,
-    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
@@ -17350,14 +17224,12 @@ fn get_view_for_ts_type_assertion<'a>(inner: &'a swc_ast::TsTypeAssertion, paren
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeLit"))]
 pub struct TsTypeLit<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeLit,
-  pub span: Span,
   pub members: Vec<TsTypeElement<'a>>,
 }
 
@@ -17412,7 +17284,6 @@ impl<'a> CastableNode<'a> for TsTypeLit<'a> {
 fn get_view_for_ts_type_lit<'a>(inner: &'a swc_ast::TsTypeLit, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeLit<'a> {
   let node = bump.alloc(TsTypeLit {
     inner,
-    span: inner.span(),
     parent,
     members: Vec::with_capacity(inner.members.len()),
   });
@@ -17421,16 +17292,19 @@ fn get_view_for_ts_type_lit<'a>(inner: &'a swc_ast::TsTypeLit, parent: Node<'a>,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeOperator"))]
 pub struct TsTypeOperator<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeOperator,
-  pub span: Span,
   pub type_ann: TsType<'a>,
-  pub op: TsTypeOperatorOp,
+}
+
+impl<'a> TsTypeOperator<'a> {
+  pub fn op(&self) -> TsTypeOperatorOp {
+    self.inner.op
+  }
 }
 
 impl<'a> Spanned for TsTypeOperator<'a> {
@@ -17482,24 +17356,20 @@ impl<'a> CastableNode<'a> for TsTypeOperator<'a> {
 fn get_view_for_ts_type_operator<'a>(inner: &'a swc_ast::TsTypeOperator, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeOperator<'a> {
   let node = bump.alloc(TsTypeOperator {
     inner,
-    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
-    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.type_ann = get_view_for_ts_type(&inner.type_ann, parent, bump);
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeParam"))]
 pub struct TsTypeParam<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParam,
-  pub span: Span,
   pub name: &'a Ident<'a>,
   pub constraint: Option<TsType<'a>>,
   pub default: Option<TsType<'a>>,
@@ -17560,7 +17430,6 @@ impl<'a> CastableNode<'a> for TsTypeParam<'a> {
 fn get_view_for_ts_type_param<'a>(inner: &'a swc_ast::TsTypeParam, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeParam<'a> {
   let node = bump.alloc(TsTypeParam {
     inner,
-    span: inner.span(),
     parent,
     name: unsafe { MaybeUninit::uninit().assume_init() },
     constraint: None,
@@ -17579,14 +17448,12 @@ fn get_view_for_ts_type_param<'a>(inner: &'a swc_ast::TsTypeParam, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeParamDecl"))]
 pub struct TsTypeParamDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParamDecl,
-  pub span: Span,
   pub params: Vec<&'a TsTypeParam<'a>>,
 }
 
@@ -17641,7 +17508,6 @@ impl<'a> CastableNode<'a> for TsTypeParamDecl<'a> {
 fn get_view_for_ts_type_param_decl<'a>(inner: &'a swc_ast::TsTypeParamDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeParamDecl<'a> {
   let node = bump.alloc(TsTypeParamDecl {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
   });
@@ -17650,14 +17516,12 @@ fn get_view_for_ts_type_param_decl<'a>(inner: &'a swc_ast::TsTypeParamDecl, pare
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeParamInstantiation"))]
 pub struct TsTypeParamInstantiation<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParamInstantiation,
-  pub span: Span,
   pub params: Vec<TsType<'a>>,
 }
 
@@ -17712,7 +17576,6 @@ impl<'a> CastableNode<'a> for TsTypeParamInstantiation<'a> {
 fn get_view_for_ts_type_param_instantiation<'a>(inner: &'a swc_ast::TsTypeParamInstantiation, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeParamInstantiation<'a> {
   let node = bump.alloc(TsTypeParamInstantiation {
     inner,
-    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
   });
@@ -17721,17 +17584,20 @@ fn get_view_for_ts_type_param_instantiation<'a>(inner: &'a swc_ast::TsTypeParamI
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypePredicate"))]
 pub struct TsTypePredicate<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypePredicate,
-  pub span: Span,
   pub param_name: TsThisTypeOrIdent<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-  pub asserts: bool,
+}
+
+impl<'a> TsTypePredicate<'a> {
+  pub fn asserts(&self) -> bool {
+    self.inner.asserts
+  }
 }
 
 impl<'a> Spanned for TsTypePredicate<'a> {
@@ -17786,11 +17652,9 @@ impl<'a> CastableNode<'a> for TsTypePredicate<'a> {
 fn get_view_for_ts_type_predicate<'a>(inner: &'a swc_ast::TsTypePredicate, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypePredicate<'a> {
   let node = bump.alloc(TsTypePredicate {
     inner,
-    span: inner.span(),
     parent,
     param_name: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
-    asserts: inner.asserts,
   });
   let parent: Node<'a> = (&*node).into();
   node.param_name = get_view_for_ts_this_type_or_ident(&inner.param_name, parent.clone(), bump);
@@ -17802,14 +17666,12 @@ fn get_view_for_ts_type_predicate<'a>(inner: &'a swc_ast::TsTypePredicate, paren
 }
 
 /// `typeof` operator
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeQuery"))]
 pub struct TsTypeQuery<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeQuery,
-  pub span: Span,
   pub expr_name: TsTypeQueryExpr<'a>,
 }
 
@@ -17862,7 +17724,6 @@ impl<'a> CastableNode<'a> for TsTypeQuery<'a> {
 fn get_view_for_ts_type_query<'a>(inner: &'a swc_ast::TsTypeQuery, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeQuery<'a> {
   let node = bump.alloc(TsTypeQuery {
     inner,
-    span: inner.span(),
     parent,
     expr_name: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -17871,14 +17732,12 @@ fn get_view_for_ts_type_query<'a>(inner: &'a swc_ast::TsTypeQuery, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsTypeRef"))]
 pub struct TsTypeRef<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeRef,
-  pub span: Span,
   pub type_name: TsEntityName<'a>,
   pub type_params: Option<&'a TsTypeParamInstantiation<'a>>,
 }
@@ -17935,7 +17794,6 @@ impl<'a> CastableNode<'a> for TsTypeRef<'a> {
 fn get_view_for_ts_type_ref<'a>(inner: &'a swc_ast::TsTypeRef, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeRef<'a> {
   let node = bump.alloc(TsTypeRef {
     inner,
-    span: inner.span(),
     parent,
     type_name: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
@@ -17949,14 +17807,12 @@ fn get_view_for_ts_type_ref<'a>(inner: &'a swc_ast::TsTypeRef, parent: Node<'a>,
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableTsUnionType"))]
 pub struct TsUnionType<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::TsUnionType,
-  pub span: Span,
   pub types: Vec<TsType<'a>>,
 }
 
@@ -18011,7 +17867,6 @@ impl<'a> CastableNode<'a> for TsUnionType<'a> {
 fn get_view_for_ts_union_type<'a>(inner: &'a swc_ast::TsUnionType, parent: Node<'a>, bump: &'a Bump) -> &'a TsUnionType<'a> {
   let node = bump.alloc(TsUnionType {
     inner,
-    span: inner.span(),
     parent,
     types: Vec::with_capacity(inner.types.len()),
   });
@@ -18020,16 +17875,19 @@ fn get_view_for_ts_union_type<'a>(inner: &'a swc_ast::TsUnionType, parent: Node<
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableUnaryExpr"))]
 pub struct UnaryExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::UnaryExpr,
-  pub span: Span,
   pub arg: Expr<'a>,
-  pub op: UnaryOp,
+}
+
+impl<'a> UnaryExpr<'a> {
+  pub fn op(&self) -> UnaryOp {
+    self.inner.op
+  }
 }
 
 impl<'a> Spanned for UnaryExpr<'a> {
@@ -18081,27 +17939,31 @@ impl<'a> CastableNode<'a> for UnaryExpr<'a> {
 fn get_view_for_unary_expr<'a>(inner: &'a swc_ast::UnaryExpr, parent: Node<'a>, bump: &'a Bump) -> &'a UnaryExpr<'a> {
   let node = bump.alloc(UnaryExpr {
     inner,
-    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
-    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = get_view_for_expr(&inner.arg, parent, bump);
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableUpdateExpr"))]
 pub struct UpdateExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::UpdateExpr,
-  pub span: Span,
   pub arg: Expr<'a>,
-  pub op: UpdateOp,
-  pub prefix: bool,
+}
+
+impl<'a> UpdateExpr<'a> {
+  pub fn op(&self) -> UpdateOp {
+    self.inner.op
+  }
+
+  pub fn prefix(&self) -> bool {
+    self.inner.prefix
+  }
 }
 
 impl<'a> Spanned for UpdateExpr<'a> {
@@ -18153,28 +18015,31 @@ impl<'a> CastableNode<'a> for UpdateExpr<'a> {
 fn get_view_for_update_expr<'a>(inner: &'a swc_ast::UpdateExpr, parent: Node<'a>, bump: &'a Bump) -> &'a UpdateExpr<'a> {
   let node = bump.alloc(UpdateExpr {
     inner,
-    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
-    op: inner.op,
-    prefix: inner.prefix,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = get_view_for_expr(&inner.arg, parent, bump);
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableVarDecl"))]
 pub struct VarDecl<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::VarDecl,
-  pub span: Span,
   pub decls: Vec<&'a VarDeclarator<'a>>,
-  pub kind: VarDeclKind,
-  pub declare: bool,
+}
+
+impl<'a> VarDecl<'a> {
+  pub fn kind(&self) -> VarDeclKind {
+    self.inner.kind
+  }
+
+  pub fn declare(&self) -> bool {
+    self.inner.declare
+  }
 }
 
 impl<'a> Spanned for VarDecl<'a> {
@@ -18228,30 +18093,30 @@ impl<'a> CastableNode<'a> for VarDecl<'a> {
 fn get_view_for_var_decl<'a>(inner: &'a swc_ast::VarDecl, parent: Node<'a>, bump: &'a Bump) -> &'a VarDecl<'a> {
   let node = bump.alloc(VarDecl {
     inner,
-    span: inner.span(),
     parent,
     decls: Vec::with_capacity(inner.decls.len()),
-    kind: inner.kind,
-    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.decls.extend(inner.decls.iter().map(|value| get_view_for_var_declarator(value, parent.clone(), bump)));
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableVarDeclarator"))]
 pub struct VarDeclarator<'a> {
-  #[serde(skip)]
   pub parent: &'a VarDecl<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::VarDeclarator,
-  pub span: Span,
   pub name: Pat<'a>,
   /// Initialization expression.
   pub init: Option<Expr<'a>>,
+}
+
+impl<'a> VarDeclarator<'a> {
   /// Typescript only
-  pub definite: bool,
+  pub fn definite(&self) -> bool {
+    self.inner.definite
+  }
 }
 
 impl<'a> Spanned for VarDeclarator<'a> {
@@ -18306,11 +18171,9 @@ impl<'a> CastableNode<'a> for VarDeclarator<'a> {
 fn get_view_for_var_declarator<'a>(inner: &'a swc_ast::VarDeclarator, parent: Node<'a>, bump: &'a Bump) -> &'a VarDeclarator<'a> {
   let node = bump.alloc(VarDeclarator {
     inner,
-    span: inner.span(),
     parent: parent.expect::<VarDecl>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
     init: None,
-    definite: inner.definite,
   });
   let parent: Node<'a> = (&*node).into();
   node.name = get_view_for_pat(&inner.name, parent.clone(), bump);
@@ -18321,14 +18184,12 @@ fn get_view_for_var_declarator<'a>(inner: &'a swc_ast::VarDeclarator, parent: No
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableWhileStmt"))]
 pub struct WhileStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::WhileStmt,
-  pub span: Span,
   pub test: Expr<'a>,
   pub body: Stmt<'a>,
 }
@@ -18383,7 +18244,6 @@ impl<'a> CastableNode<'a> for WhileStmt<'a> {
 fn get_view_for_while_stmt<'a>(inner: &'a swc_ast::WhileStmt, parent: Node<'a>, bump: &'a Bump) -> &'a WhileStmt<'a> {
   let node = bump.alloc(WhileStmt {
     inner,
-    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -18394,14 +18254,12 @@ fn get_view_for_while_stmt<'a>(inner: &'a swc_ast::WhileStmt, parent: Node<'a>, 
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableWithStmt"))]
 pub struct WithStmt<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::WithStmt,
-  pub span: Span,
   pub obj: Expr<'a>,
   pub body: Stmt<'a>,
 }
@@ -18456,7 +18314,6 @@ impl<'a> CastableNode<'a> for WithStmt<'a> {
 fn get_view_for_with_stmt<'a>(inner: &'a swc_ast::WithStmt, parent: Node<'a>, bump: &'a Bump) -> &'a WithStmt<'a> {
   let node = bump.alloc(WithStmt {
     inner,
-    span: inner.span(),
     parent,
     obj: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -18467,16 +18324,19 @@ fn get_view_for_with_stmt<'a>(inner: &'a swc_ast::WithStmt, parent: Node<'a>, bu
   node
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase", tag = "nodeKind")]
+#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(into = "crate::generated_serialize::SerializableYieldExpr"))]
 pub struct YieldExpr<'a> {
-  #[serde(skip)]
   pub parent: Node<'a>,
-  #[serde(skip)]
   pub inner: &'a swc_ast::YieldExpr,
-  pub span: Span,
   pub arg: Option<Expr<'a>>,
-  pub delegate: bool,
+}
+
+impl<'a> YieldExpr<'a> {
+  pub fn delegate(&self) -> bool {
+    self.inner.delegate
+  }
 }
 
 impl<'a> Spanned for YieldExpr<'a> {
@@ -18530,10 +18390,8 @@ impl<'a> CastableNode<'a> for YieldExpr<'a> {
 fn get_view_for_yield_expr<'a>(inner: &'a swc_ast::YieldExpr, parent: Node<'a>, bump: &'a Bump) -> &'a YieldExpr<'a> {
   let node = bump.alloc(YieldExpr {
     inner,
-    span: inner.span(),
     parent,
     arg: None,
-    delegate: inner.delegate,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = match &inner.arg {

--- a/rs-lib/src/generated.rs
+++ b/rs-lib/src/generated.rs
@@ -6291,6 +6291,7 @@ pub struct ArrayLit<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ArrayLit,
+  pub span: Span,
   pub elems: Vec<Option<&'a ExprOrSpread<'a>>>,
 }
 
@@ -6347,6 +6348,7 @@ impl<'a> CastableNode<'a> for ArrayLit<'a> {
 fn get_view_for_array_lit<'a>(inner: &'a swc_ast::ArrayLit, parent: Node<'a>, bump: &'a Bump) -> &'a ArrayLit<'a> {
   let node = bump.alloc(ArrayLit {
     inner,
+    span: inner.span(),
     parent,
     elems: Vec::with_capacity(inner.elems.len()),
   });
@@ -6365,6 +6367,7 @@ pub struct ArrayPat<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ArrayPat,
+  pub span: Span,
   pub elems: Vec<Option<Pat<'a>>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   /// Only in an ambient context
@@ -6427,6 +6430,7 @@ impl<'a> CastableNode<'a> for ArrayPat<'a> {
 fn get_view_for_array_pat<'a>(inner: &'a swc_ast::ArrayPat, parent: Node<'a>, bump: &'a Bump) -> &'a ArrayPat<'a> {
   let node = bump.alloc(ArrayPat {
     inner,
+    span: inner.span(),
     parent,
     elems: Vec::with_capacity(inner.elems.len()),
     type_ann: None,
@@ -6451,6 +6455,7 @@ pub struct ArrowExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ArrowExpr,
+  pub span: Span,
   pub params: Vec<Pat<'a>>,
   pub body: BlockStmtOrExpr<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -6517,6 +6522,7 @@ impl<'a> CastableNode<'a> for ArrowExpr<'a> {
 fn get_view_for_arrow_expr<'a>(inner: &'a swc_ast::ArrowExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ArrowExpr<'a> {
   let node = bump.alloc(ArrowExpr {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -6546,6 +6552,7 @@ pub struct AssignExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::AssignExpr,
+  pub span: Span,
   pub left: PatOrExpr<'a>,
   pub right: Expr<'a>,
   pub op: AssignOp,
@@ -6601,6 +6608,7 @@ impl<'a> CastableNode<'a> for AssignExpr<'a> {
 fn get_view_for_assign_expr<'a>(inner: &'a swc_ast::AssignExpr, parent: Node<'a>, bump: &'a Bump) -> &'a AssignExpr<'a> {
   let node = bump.alloc(AssignExpr {
     inner,
+    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -6619,6 +6627,7 @@ pub struct AssignPat<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::AssignPat,
+  pub span: Span,
   pub left: Pat<'a>,
   pub right: Expr<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -6677,6 +6686,7 @@ impl<'a> CastableNode<'a> for AssignPat<'a> {
 fn get_view_for_assign_pat<'a>(inner: &'a swc_ast::AssignPat, parent: Node<'a>, bump: &'a Bump) -> &'a AssignPat<'a> {
   let node = bump.alloc(AssignPat {
     inner,
+    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -6700,6 +6710,7 @@ pub struct AssignPatProp<'a> {
   pub parent: &'a ObjectPat<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::AssignPatProp,
+  pub span: Span,
   pub key: &'a Ident<'a>,
   pub value: Option<Expr<'a>>,
 }
@@ -6756,6 +6767,7 @@ impl<'a> CastableNode<'a> for AssignPatProp<'a> {
 fn get_view_for_assign_pat_prop<'a>(inner: &'a swc_ast::AssignPatProp, parent: Node<'a>, bump: &'a Bump) -> &'a AssignPatProp<'a> {
   let node = bump.alloc(AssignPatProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ObjectPat>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
@@ -6776,6 +6788,7 @@ pub struct AssignProp<'a> {
   pub parent: &'a ObjectLit<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::AssignProp,
+  pub span: Span,
   pub key: &'a Ident<'a>,
   pub value: Expr<'a>,
 }
@@ -6830,6 +6843,7 @@ impl<'a> CastableNode<'a> for AssignProp<'a> {
 fn get_view_for_assign_prop<'a>(inner: &'a swc_ast::AssignProp, parent: Node<'a>, bump: &'a Bump) -> &'a AssignProp<'a> {
   let node = bump.alloc(AssignProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: unsafe { MaybeUninit::uninit().assume_init() },
@@ -6847,6 +6861,7 @@ pub struct AwaitExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::AwaitExpr,
+  pub span: Span,
   pub arg: Expr<'a>,
 }
 
@@ -6899,6 +6914,7 @@ impl<'a> CastableNode<'a> for AwaitExpr<'a> {
 fn get_view_for_await_expr<'a>(inner: &'a swc_ast::AwaitExpr, parent: Node<'a>, bump: &'a Bump) -> &'a AwaitExpr<'a> {
   let node = bump.alloc(AwaitExpr {
     inner,
+    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -6914,6 +6930,7 @@ pub struct BigInt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::BigInt,
+  pub span: Span,
   pub value: &'a num_bigint::BigInt,
 }
 
@@ -6964,6 +6981,7 @@ impl<'a> CastableNode<'a> for BigInt<'a> {
 fn get_view_for_big_int<'a>(inner: &'a swc_ast::BigInt, parent: Node<'a>, bump: &'a Bump) -> &'a BigInt<'a> {
   let node = bump.alloc(BigInt {
     inner,
+    span: inner.span(),
     parent,
     value: &inner.value,
   });
@@ -6977,6 +6995,7 @@ pub struct BinExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::BinExpr,
+  pub span: Span,
   pub left: Expr<'a>,
   pub right: Expr<'a>,
   pub op: BinaryOp,
@@ -7032,6 +7051,7 @@ impl<'a> CastableNode<'a> for BinExpr<'a> {
 fn get_view_for_bin_expr<'a>(inner: &'a swc_ast::BinExpr, parent: Node<'a>, bump: &'a Bump) -> &'a BinExpr<'a> {
   let node = bump.alloc(BinExpr {
     inner,
+    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -7051,6 +7071,7 @@ pub struct BindingIdent<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::BindingIdent,
+  pub span: Span,
   pub id: &'a Ident<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
 }
@@ -7107,6 +7128,7 @@ impl<'a> CastableNode<'a> for BindingIdent<'a> {
 fn get_view_for_binding_ident<'a>(inner: &'a swc_ast::BindingIdent, parent: Node<'a>, bump: &'a Bump) -> &'a BindingIdent<'a> {
   let node = bump.alloc(BindingIdent {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
@@ -7128,6 +7150,7 @@ pub struct BlockStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::BlockStmt,
+  pub span: Span,
   pub stmts: Vec<Stmt<'a>>,
 }
 
@@ -7182,6 +7205,7 @@ impl<'a> CastableNode<'a> for BlockStmt<'a> {
 fn get_view_for_block_stmt<'a>(inner: &'a swc_ast::BlockStmt, parent: Node<'a>, bump: &'a Bump) -> &'a BlockStmt<'a> {
   let node = bump.alloc(BlockStmt {
     inner,
+    span: inner.span(),
     parent,
     stmts: Vec::with_capacity(inner.stmts.len()),
   });
@@ -7197,6 +7221,7 @@ pub struct Bool<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Bool,
+  pub span: Span,
   pub value: bool,
 }
 
@@ -7247,6 +7272,7 @@ impl<'a> CastableNode<'a> for Bool<'a> {
 fn get_view_for_bool<'a>(inner: &'a swc_ast::Bool, parent: Node<'a>, bump: &'a Bump) -> &'a Bool<'a> {
   let node = bump.alloc(Bool {
     inner,
+    span: inner.span(),
     parent,
     value: inner.value,
   });
@@ -7260,6 +7286,7 @@ pub struct BreakStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::BreakStmt,
+  pub span: Span,
   pub label: Option<&'a Ident<'a>>,
 }
 
@@ -7314,6 +7341,7 @@ impl<'a> CastableNode<'a> for BreakStmt<'a> {
 fn get_view_for_break_stmt<'a>(inner: &'a swc_ast::BreakStmt, parent: Node<'a>, bump: &'a Bump) -> &'a BreakStmt<'a> {
   let node = bump.alloc(BreakStmt {
     inner,
+    span: inner.span(),
     parent,
     label: None,
   });
@@ -7332,6 +7360,7 @@ pub struct CallExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::CallExpr,
+  pub span: Span,
   pub callee: ExprOrSuper<'a>,
   pub args: Vec<&'a ExprOrSpread<'a>>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -7392,6 +7421,7 @@ impl<'a> CastableNode<'a> for CallExpr<'a> {
 fn get_view_for_call_expr<'a>(inner: &'a swc_ast::CallExpr, parent: Node<'a>, bump: &'a Bump) -> &'a CallExpr<'a> {
   let node = bump.alloc(CallExpr {
     inner,
+    span: inner.span(),
     parent,
     callee: unsafe { MaybeUninit::uninit().assume_init() },
     args: Vec::with_capacity(inner.args.len()),
@@ -7414,6 +7444,7 @@ pub struct CatchClause<'a> {
   pub parent: &'a TryStmt<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::CatchClause,
+  pub span: Span,
   /// es2019
   ///
   /// The param is null if the catch binding is omitted. E.g., try { foo() }
@@ -7474,6 +7505,7 @@ impl<'a> CastableNode<'a> for CatchClause<'a> {
 fn get_view_for_catch_clause<'a>(inner: &'a swc_ast::CatchClause, parent: Node<'a>, bump: &'a Bump) -> &'a CatchClause<'a> {
   let node = bump.alloc(CatchClause {
     inner,
+    span: inner.span(),
     parent: parent.expect::<TryStmt>(),
     param: None,
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -7494,6 +7526,7 @@ pub struct Class<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Class,
+  pub span: Span,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub body: Vec<ClassMember<'a>>,
   pub super_class: Option<Expr<'a>>,
@@ -7570,6 +7603,7 @@ impl<'a> CastableNode<'a> for Class<'a> {
 fn get_view_for_class<'a>(inner: &'a swc_ast::Class, parent: Node<'a>, bump: &'a Bump) -> &'a Class<'a> {
   let node = bump.alloc(Class {
     inner,
+    span: inner.span(),
     parent,
     decorators: Vec::with_capacity(inner.decorators.len()),
     body: Vec::with_capacity(inner.body.len()),
@@ -7605,6 +7639,7 @@ pub struct ClassDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ClassDecl,
+  pub span: Span,
   pub ident: &'a Ident<'a>,
   pub class: &'a Class<'a>,
   pub declare: bool,
@@ -7660,6 +7695,7 @@ impl<'a> CastableNode<'a> for ClassDecl<'a> {
 fn get_view_for_class_decl<'a>(inner: &'a swc_ast::ClassDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ClassDecl<'a> {
   let node = bump.alloc(ClassDecl {
     inner,
+    span: inner.span(),
     parent,
     ident: unsafe { MaybeUninit::uninit().assume_init() },
     class: unsafe { MaybeUninit::uninit().assume_init() },
@@ -7679,6 +7715,7 @@ pub struct ClassExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ClassExpr,
+  pub span: Span,
   pub ident: Option<&'a Ident<'a>>,
   pub class: &'a Class<'a>,
 }
@@ -7735,6 +7772,7 @@ impl<'a> CastableNode<'a> for ClassExpr<'a> {
 fn get_view_for_class_expr<'a>(inner: &'a swc_ast::ClassExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ClassExpr<'a> {
   let node = bump.alloc(ClassExpr {
     inner,
+    span: inner.span(),
     parent,
     ident: None,
     class: unsafe { MaybeUninit::uninit().assume_init() },
@@ -7755,6 +7793,7 @@ pub struct ClassMethod<'a> {
   pub parent: &'a Class<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ClassMethod,
+  pub span: Span,
   pub key: PropName<'a>,
   pub function: &'a Function<'a>,
   pub kind: MethodKind,
@@ -7816,6 +7855,7 @@ impl<'a> CastableNode<'a> for ClassMethod<'a> {
 fn get_view_for_class_method<'a>(inner: &'a swc_ast::ClassMethod, parent: Node<'a>, bump: &'a Bump) -> &'a ClassMethod<'a> {
   let node = bump.alloc(ClassMethod {
     inner,
+    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
@@ -7838,6 +7878,7 @@ pub struct ClassProp<'a> {
   pub parent: &'a Class<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ClassProp,
+  pub span: Span,
   pub key: Expr<'a>,
   pub value: Option<Expr<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -7912,6 +7953,7 @@ impl<'a> CastableNode<'a> for ClassProp<'a> {
 fn get_view_for_class_prop<'a>(inner: &'a swc_ast::ClassProp, parent: Node<'a>, bump: &'a Bump) -> &'a ClassProp<'a> {
   let node = bump.alloc(ClassProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
@@ -7947,6 +7989,7 @@ pub struct ComputedPropName<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ComputedPropName,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -7999,6 +8042,7 @@ impl<'a> CastableNode<'a> for ComputedPropName<'a> {
 fn get_view_for_computed_prop_name<'a>(inner: &'a swc_ast::ComputedPropName, parent: Node<'a>, bump: &'a Bump) -> &'a ComputedPropName<'a> {
   let node = bump.alloc(ComputedPropName {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8014,6 +8058,7 @@ pub struct CondExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::CondExpr,
+  pub span: Span,
   pub test: Expr<'a>,
   pub cons: Expr<'a>,
   pub alt: Expr<'a>,
@@ -8070,6 +8115,7 @@ impl<'a> CastableNode<'a> for CondExpr<'a> {
 fn get_view_for_cond_expr<'a>(inner: &'a swc_ast::CondExpr, parent: Node<'a>, bump: &'a Bump) -> &'a CondExpr<'a> {
   let node = bump.alloc(CondExpr {
     inner,
+    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     cons: unsafe { MaybeUninit::uninit().assume_init() },
@@ -8089,6 +8135,7 @@ pub struct Constructor<'a> {
   pub parent: &'a Class<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Constructor,
+  pub span: Span,
   pub key: PropName<'a>,
   pub params: Vec<ParamOrTsParamProp<'a>>,
   pub body: Option<&'a BlockStmt<'a>>,
@@ -8151,6 +8198,7 @@ impl<'a> CastableNode<'a> for Constructor<'a> {
 fn get_view_for_constructor<'a>(inner: &'a swc_ast::Constructor, parent: Node<'a>, bump: &'a Bump) -> &'a Constructor<'a> {
   let node = bump.alloc(Constructor {
     inner,
+    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     params: Vec::with_capacity(inner.params.len()),
@@ -8175,6 +8223,7 @@ pub struct ContinueStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ContinueStmt,
+  pub span: Span,
   pub label: Option<&'a Ident<'a>>,
 }
 
@@ -8229,6 +8278,7 @@ impl<'a> CastableNode<'a> for ContinueStmt<'a> {
 fn get_view_for_continue_stmt<'a>(inner: &'a swc_ast::ContinueStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ContinueStmt<'a> {
   let node = bump.alloc(ContinueStmt {
     inner,
+    span: inner.span(),
     parent,
     label: None,
   });
@@ -8247,6 +8297,7 @@ pub struct DebuggerStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::DebuggerStmt,
+  pub span: Span,
 }
 
 impl<'a> Spanned for DebuggerStmt<'a> {
@@ -8296,6 +8347,7 @@ impl<'a> CastableNode<'a> for DebuggerStmt<'a> {
 fn get_view_for_debugger_stmt<'a>(inner: &'a swc_ast::DebuggerStmt, parent: Node<'a>, bump: &'a Bump) -> &'a DebuggerStmt<'a> {
   let node = bump.alloc(DebuggerStmt {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -8308,6 +8360,7 @@ pub struct Decorator<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Decorator,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -8360,6 +8413,7 @@ impl<'a> CastableNode<'a> for Decorator<'a> {
 fn get_view_for_decorator<'a>(inner: &'a swc_ast::Decorator, parent: Node<'a>, bump: &'a Bump) -> &'a Decorator<'a> {
   let node = bump.alloc(Decorator {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8375,6 +8429,7 @@ pub struct DoWhileStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::DoWhileStmt,
+  pub span: Span,
   pub test: Expr<'a>,
   pub body: Stmt<'a>,
 }
@@ -8429,6 +8484,7 @@ impl<'a> CastableNode<'a> for DoWhileStmt<'a> {
 fn get_view_for_do_while_stmt<'a>(inner: &'a swc_ast::DoWhileStmt, parent: Node<'a>, bump: &'a Bump) -> &'a DoWhileStmt<'a> {
   let node = bump.alloc(DoWhileStmt {
     inner,
+    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -8446,6 +8502,7 @@ pub struct EmptyStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::EmptyStmt,
+  pub span: Span,
 }
 
 impl<'a> Spanned for EmptyStmt<'a> {
@@ -8495,6 +8552,7 @@ impl<'a> CastableNode<'a> for EmptyStmt<'a> {
 fn get_view_for_empty_stmt<'a>(inner: &'a swc_ast::EmptyStmt, parent: Node<'a>, bump: &'a Bump) -> &'a EmptyStmt<'a> {
   let node = bump.alloc(EmptyStmt {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -8508,6 +8566,7 @@ pub struct ExportAll<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExportAll,
+  pub span: Span,
   pub src: &'a Str<'a>,
   pub asserts: Option<&'a ObjectLit<'a>>,
 }
@@ -8564,6 +8623,7 @@ impl<'a> CastableNode<'a> for ExportAll<'a> {
 fn get_view_for_export_all<'a>(inner: &'a swc_ast::ExportAll, parent: Node<'a>, bump: &'a Bump) -> &'a ExportAll<'a> {
   let node = bump.alloc(ExportAll {
     inner,
+    span: inner.span(),
     parent,
     src: unsafe { MaybeUninit::uninit().assume_init() },
     asserts: None,
@@ -8584,6 +8644,7 @@ pub struct ExportDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExportDecl,
+  pub span: Span,
   pub decl: Decl<'a>,
 }
 
@@ -8636,6 +8697,7 @@ impl<'a> CastableNode<'a> for ExportDecl<'a> {
 fn get_view_for_export_decl<'a>(inner: &'a swc_ast::ExportDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDecl<'a> {
   let node = bump.alloc(ExportDecl {
     inner,
+    span: inner.span(),
     parent,
     decl: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8651,6 +8713,7 @@ pub struct ExportDefaultDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultDecl,
+  pub span: Span,
   pub decl: DefaultDecl<'a>,
 }
 
@@ -8703,6 +8766,7 @@ impl<'a> CastableNode<'a> for ExportDefaultDecl<'a> {
 fn get_view_for_export_default_decl<'a>(inner: &'a swc_ast::ExportDefaultDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDefaultDecl<'a> {
   let node = bump.alloc(ExportDefaultDecl {
     inner,
+    span: inner.span(),
     parent,
     decl: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8718,6 +8782,7 @@ pub struct ExportDefaultExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultExpr,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -8770,6 +8835,7 @@ impl<'a> CastableNode<'a> for ExportDefaultExpr<'a> {
 fn get_view_for_export_default_expr<'a>(inner: &'a swc_ast::ExportDefaultExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDefaultExpr<'a> {
   let node = bump.alloc(ExportDefaultExpr {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8785,6 +8851,7 @@ pub struct ExportDefaultSpecifier<'a> {
   pub parent: &'a NamedExport<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultSpecifier,
+  pub span: Span,
   pub exported: &'a Ident<'a>,
 }
 
@@ -8837,6 +8904,7 @@ impl<'a> CastableNode<'a> for ExportDefaultSpecifier<'a> {
 fn get_view_for_export_default_specifier<'a>(inner: &'a swc_ast::ExportDefaultSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ExportDefaultSpecifier<'a> {
   let node = bump.alloc(ExportDefaultSpecifier {
     inner,
+    span: inner.span(),
     parent: parent.expect::<NamedExport>(),
     exported: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8852,6 +8920,7 @@ pub struct ExportNamedSpecifier<'a> {
   pub parent: &'a NamedExport<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExportNamedSpecifier,
+  pub span: Span,
   /// `foo` in `export { foo as bar }`
   pub orig: &'a Ident<'a>,
   /// `Some(bar)` in `export { foo as bar }`
@@ -8910,6 +8979,7 @@ impl<'a> CastableNode<'a> for ExportNamedSpecifier<'a> {
 fn get_view_for_export_named_specifier<'a>(inner: &'a swc_ast::ExportNamedSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ExportNamedSpecifier<'a> {
   let node = bump.alloc(ExportNamedSpecifier {
     inner,
+    span: inner.span(),
     parent: parent.expect::<NamedExport>(),
     orig: unsafe { MaybeUninit::uninit().assume_init() },
     exported: None,
@@ -8931,6 +9001,7 @@ pub struct ExportNamespaceSpecifier<'a> {
   pub parent: &'a NamedExport<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExportNamespaceSpecifier,
+  pub span: Span,
   pub name: &'a Ident<'a>,
 }
 
@@ -8983,6 +9054,7 @@ impl<'a> CastableNode<'a> for ExportNamespaceSpecifier<'a> {
 fn get_view_for_export_namespace_specifier<'a>(inner: &'a swc_ast::ExportNamespaceSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ExportNamespaceSpecifier<'a> {
   let node = bump.alloc(ExportNamespaceSpecifier {
     inner,
+    span: inner.span(),
     parent: parent.expect::<NamedExport>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -8998,6 +9070,7 @@ pub struct ExprOrSpread<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExprOrSpread,
+  pub span: Span,
   pub expr: Expr<'a>,
   pub spread: &'a Option<swc_common::Span>,
 }
@@ -9051,6 +9124,7 @@ impl<'a> CastableNode<'a> for ExprOrSpread<'a> {
 fn get_view_for_expr_or_spread<'a>(inner: &'a swc_ast::ExprOrSpread, parent: Node<'a>, bump: &'a Bump) -> &'a ExprOrSpread<'a> {
   let node = bump.alloc(ExprOrSpread {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     spread: &inner.spread,
@@ -9067,6 +9141,7 @@ pub struct ExprStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ExprStmt,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -9119,6 +9194,7 @@ impl<'a> CastableNode<'a> for ExprStmt<'a> {
 fn get_view_for_expr_stmt<'a>(inner: &'a swc_ast::ExprStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ExprStmt<'a> {
   let node = bump.alloc(ExprStmt {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -9134,6 +9210,7 @@ pub struct FnDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::FnDecl,
+  pub span: Span,
   pub ident: &'a Ident<'a>,
   pub function: &'a Function<'a>,
   pub declare: bool,
@@ -9189,6 +9266,7 @@ impl<'a> CastableNode<'a> for FnDecl<'a> {
 fn get_view_for_fn_decl<'a>(inner: &'a swc_ast::FnDecl, parent: Node<'a>, bump: &'a Bump) -> &'a FnDecl<'a> {
   let node = bump.alloc(FnDecl {
     inner,
+    span: inner.span(),
     parent,
     ident: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9208,6 +9286,7 @@ pub struct FnExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::FnExpr,
+  pub span: Span,
   pub ident: Option<&'a Ident<'a>>,
   pub function: &'a Function<'a>,
 }
@@ -9264,6 +9343,7 @@ impl<'a> CastableNode<'a> for FnExpr<'a> {
 fn get_view_for_fn_expr<'a>(inner: &'a swc_ast::FnExpr, parent: Node<'a>, bump: &'a Bump) -> &'a FnExpr<'a> {
   let node = bump.alloc(FnExpr {
     inner,
+    span: inner.span(),
     parent,
     ident: None,
     function: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9284,6 +9364,7 @@ pub struct ForInStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ForInStmt,
+  pub span: Span,
   pub left: VarDeclOrPat<'a>,
   pub right: Expr<'a>,
   pub body: Stmt<'a>,
@@ -9340,6 +9421,7 @@ impl<'a> CastableNode<'a> for ForInStmt<'a> {
 fn get_view_for_for_in_stmt<'a>(inner: &'a swc_ast::ForInStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ForInStmt<'a> {
   let node = bump.alloc(ForInStmt {
     inner,
+    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9359,6 +9441,7 @@ pub struct ForOfStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ForOfStmt,
+  pub span: Span,
   pub left: VarDeclOrPat<'a>,
   pub right: Expr<'a>,
   pub body: Stmt<'a>,
@@ -9421,6 +9504,7 @@ impl<'a> CastableNode<'a> for ForOfStmt<'a> {
 fn get_view_for_for_of_stmt<'a>(inner: &'a swc_ast::ForOfStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ForOfStmt<'a> {
   let node = bump.alloc(ForOfStmt {
     inner,
+    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9441,6 +9525,7 @@ pub struct ForStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ForStmt,
+  pub span: Span,
   pub init: Option<VarDeclOrExpr<'a>>,
   pub test: Option<Expr<'a>>,
   pub update: Option<Expr<'a>>,
@@ -9505,6 +9590,7 @@ impl<'a> CastableNode<'a> for ForStmt<'a> {
 fn get_view_for_for_stmt<'a>(inner: &'a swc_ast::ForStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ForStmt<'a> {
   let node = bump.alloc(ForStmt {
     inner,
+    span: inner.span(),
     parent,
     init: None,
     test: None,
@@ -9536,6 +9622,7 @@ pub struct Function<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Function,
+  pub span: Span,
   pub params: Vec<&'a Param<'a>>,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub body: Option<&'a BlockStmt<'a>>,
@@ -9610,6 +9697,7 @@ impl<'a> CastableNode<'a> for Function<'a> {
 fn get_view_for_function<'a>(inner: &'a swc_ast::Function, parent: Node<'a>, bump: &'a Bump) -> &'a Function<'a> {
   let node = bump.alloc(Function {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     decorators: Vec::with_capacity(inner.decorators.len()),
@@ -9644,6 +9732,7 @@ pub struct GetterProp<'a> {
   pub parent: &'a ObjectLit<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::GetterProp,
+  pub span: Span,
   pub key: PropName<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub body: Option<&'a BlockStmt<'a>>,
@@ -9704,6 +9793,7 @@ impl<'a> CastableNode<'a> for GetterProp<'a> {
 fn get_view_for_getter_prop<'a>(inner: &'a swc_ast::GetterProp, parent: Node<'a>, bump: &'a Bump) -> &'a GetterProp<'a> {
   let node = bump.alloc(GetterProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
@@ -9730,6 +9820,7 @@ pub struct Ident<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Ident,
+  pub span: Span,
   pub sym: &'a swc_atoms::JsWord,
   /// TypeScript only. Used in case of an optional parameter.
   pub optional: bool,
@@ -9782,6 +9873,7 @@ impl<'a> CastableNode<'a> for Ident<'a> {
 fn get_view_for_ident<'a>(inner: &'a swc_ast::Ident, parent: Node<'a>, bump: &'a Bump) -> &'a Ident<'a> {
   let node = bump.alloc(Ident {
     inner,
+    span: inner.span(),
     parent,
     sym: &inner.sym,
     optional: inner.optional,
@@ -9796,6 +9888,7 @@ pub struct IfStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::IfStmt,
+  pub span: Span,
   pub test: Expr<'a>,
   pub cons: Stmt<'a>,
   pub alt: Option<Stmt<'a>>,
@@ -9854,6 +9947,7 @@ impl<'a> CastableNode<'a> for IfStmt<'a> {
 fn get_view_for_if_stmt<'a>(inner: &'a swc_ast::IfStmt, parent: Node<'a>, bump: &'a Bump) -> &'a IfStmt<'a> {
   let node = bump.alloc(IfStmt {
     inner,
+    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     cons: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9876,6 +9970,7 @@ pub struct ImportDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ImportDecl,
+  pub span: Span,
   pub specifiers: Vec<ImportSpecifier<'a>>,
   pub src: &'a Str<'a>,
   pub asserts: Option<&'a ObjectLit<'a>>,
@@ -9937,6 +10032,7 @@ impl<'a> CastableNode<'a> for ImportDecl<'a> {
 fn get_view_for_import_decl<'a>(inner: &'a swc_ast::ImportDecl, parent: Node<'a>, bump: &'a Bump) -> &'a ImportDecl<'a> {
   let node = bump.alloc(ImportDecl {
     inner,
+    span: inner.span(),
     parent,
     specifiers: Vec::with_capacity(inner.specifiers.len()),
     src: unsafe { MaybeUninit::uninit().assume_init() },
@@ -9961,6 +10057,7 @@ pub struct ImportDefaultSpecifier<'a> {
   pub parent: &'a ImportDecl<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ImportDefaultSpecifier,
+  pub span: Span,
   pub local: &'a Ident<'a>,
 }
 
@@ -10013,6 +10110,7 @@ impl<'a> CastableNode<'a> for ImportDefaultSpecifier<'a> {
 fn get_view_for_import_default_specifier<'a>(inner: &'a swc_ast::ImportDefaultSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ImportDefaultSpecifier<'a> {
   let node = bump.alloc(ImportDefaultSpecifier {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ImportDecl>(),
     local: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10031,6 +10129,7 @@ pub struct ImportNamedSpecifier<'a> {
   pub parent: &'a ImportDecl<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ImportNamedSpecifier,
+  pub span: Span,
   pub local: &'a Ident<'a>,
   pub imported: Option<&'a Ident<'a>>,
 }
@@ -10087,6 +10186,7 @@ impl<'a> CastableNode<'a> for ImportNamedSpecifier<'a> {
 fn get_view_for_import_named_specifier<'a>(inner: &'a swc_ast::ImportNamedSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ImportNamedSpecifier<'a> {
   let node = bump.alloc(ImportNamedSpecifier {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ImportDecl>(),
     local: unsafe { MaybeUninit::uninit().assume_init() },
     imported: None,
@@ -10108,6 +10208,7 @@ pub struct ImportStarAsSpecifier<'a> {
   pub parent: &'a ImportDecl<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ImportStarAsSpecifier,
+  pub span: Span,
   pub local: &'a Ident<'a>,
 }
 
@@ -10160,6 +10261,7 @@ impl<'a> CastableNode<'a> for ImportStarAsSpecifier<'a> {
 fn get_view_for_import_star_as_specifier<'a>(inner: &'a swc_ast::ImportStarAsSpecifier, parent: Node<'a>, bump: &'a Bump) -> &'a ImportStarAsSpecifier<'a> {
   let node = bump.alloc(ImportStarAsSpecifier {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ImportDecl>(),
     local: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10176,6 +10278,7 @@ pub struct Invalid<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Invalid,
+  pub span: Span,
 }
 
 impl<'a> Spanned for Invalid<'a> {
@@ -10225,6 +10328,7 @@ impl<'a> CastableNode<'a> for Invalid<'a> {
 fn get_view_for_invalid<'a>(inner: &'a swc_ast::Invalid, parent: Node<'a>, bump: &'a Bump) -> &'a Invalid<'a> {
   let node = bump.alloc(Invalid {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -10237,6 +10341,7 @@ pub struct JSXAttr<'a> {
   pub parent: &'a JSXOpeningElement<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXAttr,
+  pub span: Span,
   pub name: JSXAttrName<'a>,
   /// Babel uses Expr instead of JSXAttrValue
   pub value: Option<JSXAttrValue<'a>>,
@@ -10294,6 +10399,7 @@ impl<'a> CastableNode<'a> for JSXAttr<'a> {
 fn get_view_for_jsxattr<'a>(inner: &'a swc_ast::JSXAttr, parent: Node<'a>, bump: &'a Bump) -> &'a JSXAttr<'a> {
   let node = bump.alloc(JSXAttr {
     inner,
+    span: inner.span(),
     parent: parent.expect::<JSXOpeningElement>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
@@ -10314,6 +10420,7 @@ pub struct JSXClosingElement<'a> {
   pub parent: &'a JSXElement<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXClosingElement,
+  pub span: Span,
   pub name: JSXElementName<'a>,
 }
 
@@ -10366,6 +10473,7 @@ impl<'a> CastableNode<'a> for JSXClosingElement<'a> {
 fn get_view_for_jsxclosing_element<'a>(inner: &'a swc_ast::JSXClosingElement, parent: Node<'a>, bump: &'a Bump) -> &'a JSXClosingElement<'a> {
   let node = bump.alloc(JSXClosingElement {
     inner,
+    span: inner.span(),
     parent: parent.expect::<JSXElement>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10381,6 +10489,7 @@ pub struct JSXClosingFragment<'a> {
   pub parent: &'a JSXFragment<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXClosingFragment,
+  pub span: Span,
 }
 
 impl<'a> Spanned for JSXClosingFragment<'a> {
@@ -10430,6 +10539,7 @@ impl<'a> CastableNode<'a> for JSXClosingFragment<'a> {
 fn get_view_for_jsxclosing_fragment<'a>(inner: &'a swc_ast::JSXClosingFragment, parent: Node<'a>, bump: &'a Bump) -> &'a JSXClosingFragment<'a> {
   let node = bump.alloc(JSXClosingFragment {
     inner,
+    span: inner.span(),
     parent: parent.expect::<JSXFragment>(),
   });
   node
@@ -10442,6 +10552,7 @@ pub struct JSXElement<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXElement,
+  pub span: Span,
   pub opening: &'a JSXOpeningElement<'a>,
   pub children: Vec<JSXElementChild<'a>>,
   pub closing: Option<&'a JSXClosingElement<'a>>,
@@ -10502,6 +10613,7 @@ impl<'a> CastableNode<'a> for JSXElement<'a> {
 fn get_view_for_jsxelement<'a>(inner: &'a swc_ast::JSXElement, parent: Node<'a>, bump: &'a Bump) -> &'a JSXElement<'a> {
   let node = bump.alloc(JSXElement {
     inner,
+    span: inner.span(),
     parent,
     opening: unsafe { MaybeUninit::uninit().assume_init() },
     children: Vec::with_capacity(inner.children.len()),
@@ -10524,6 +10636,7 @@ pub struct JSXEmptyExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXEmptyExpr,
+  pub span: Span,
 }
 
 impl<'a> Spanned for JSXEmptyExpr<'a> {
@@ -10573,6 +10686,7 @@ impl<'a> CastableNode<'a> for JSXEmptyExpr<'a> {
 fn get_view_for_jsxempty_expr<'a>(inner: &'a swc_ast::JSXEmptyExpr, parent: Node<'a>, bump: &'a Bump) -> &'a JSXEmptyExpr<'a> {
   let node = bump.alloc(JSXEmptyExpr {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -10585,6 +10699,7 @@ pub struct JSXExprContainer<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXExprContainer,
+  pub span: Span,
   pub expr: JSXExpr<'a>,
 }
 
@@ -10637,6 +10752,7 @@ impl<'a> CastableNode<'a> for JSXExprContainer<'a> {
 fn get_view_for_jsxexpr_container<'a>(inner: &'a swc_ast::JSXExprContainer, parent: Node<'a>, bump: &'a Bump) -> &'a JSXExprContainer<'a> {
   let node = bump.alloc(JSXExprContainer {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -10652,6 +10768,7 @@ pub struct JSXFragment<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXFragment,
+  pub span: Span,
   pub opening: &'a JSXOpeningFragment<'a>,
   pub children: Vec<JSXElementChild<'a>>,
   pub closing: &'a JSXClosingFragment<'a>,
@@ -10710,6 +10827,7 @@ impl<'a> CastableNode<'a> for JSXFragment<'a> {
 fn get_view_for_jsxfragment<'a>(inner: &'a swc_ast::JSXFragment, parent: Node<'a>, bump: &'a Bump) -> &'a JSXFragment<'a> {
   let node = bump.alloc(JSXFragment {
     inner,
+    span: inner.span(),
     parent,
     opening: unsafe { MaybeUninit::uninit().assume_init() },
     children: Vec::with_capacity(inner.children.len()),
@@ -10729,6 +10847,7 @@ pub struct JSXMemberExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXMemberExpr,
+  pub span: Span,
   pub obj: JSXObject<'a>,
   pub prop: &'a Ident<'a>,
 }
@@ -10783,6 +10902,7 @@ impl<'a> CastableNode<'a> for JSXMemberExpr<'a> {
 fn get_view_for_jsxmember_expr<'a>(inner: &'a swc_ast::JSXMemberExpr, parent: Node<'a>, bump: &'a Bump) -> &'a JSXMemberExpr<'a> {
   let node = bump.alloc(JSXMemberExpr {
     inner,
+    span: inner.span(),
     parent,
     obj: unsafe { MaybeUninit::uninit().assume_init() },
     prop: unsafe { MaybeUninit::uninit().assume_init() },
@@ -10801,6 +10921,7 @@ pub struct JSXNamespacedName<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXNamespacedName,
+  pub span: Span,
   pub ns: &'a Ident<'a>,
   pub name: &'a Ident<'a>,
 }
@@ -10855,6 +10976,7 @@ impl<'a> CastableNode<'a> for JSXNamespacedName<'a> {
 fn get_view_for_jsxnamespaced_name<'a>(inner: &'a swc_ast::JSXNamespacedName, parent: Node<'a>, bump: &'a Bump) -> &'a JSXNamespacedName<'a> {
   let node = bump.alloc(JSXNamespacedName {
     inner,
+    span: inner.span(),
     parent,
     ns: unsafe { MaybeUninit::uninit().assume_init() },
     name: unsafe { MaybeUninit::uninit().assume_init() },
@@ -10872,6 +10994,7 @@ pub struct JSXOpeningElement<'a> {
   pub parent: &'a JSXElement<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXOpeningElement,
+  pub span: Span,
   pub name: JSXElementName<'a>,
   pub attrs: Vec<JSXAttrOrSpread<'a>>,
   /// Note: This field's name is different from one from babel because it is
@@ -10935,6 +11058,7 @@ impl<'a> CastableNode<'a> for JSXOpeningElement<'a> {
 fn get_view_for_jsxopening_element<'a>(inner: &'a swc_ast::JSXOpeningElement, parent: Node<'a>, bump: &'a Bump) -> &'a JSXOpeningElement<'a> {
   let node = bump.alloc(JSXOpeningElement {
     inner,
+    span: inner.span(),
     parent: parent.expect::<JSXElement>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
     attrs: Vec::with_capacity(inner.attrs.len()),
@@ -10958,6 +11082,7 @@ pub struct JSXOpeningFragment<'a> {
   pub parent: &'a JSXFragment<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXOpeningFragment,
+  pub span: Span,
 }
 
 impl<'a> Spanned for JSXOpeningFragment<'a> {
@@ -11007,6 +11132,7 @@ impl<'a> CastableNode<'a> for JSXOpeningFragment<'a> {
 fn get_view_for_jsxopening_fragment<'a>(inner: &'a swc_ast::JSXOpeningFragment, parent: Node<'a>, bump: &'a Bump) -> &'a JSXOpeningFragment<'a> {
   let node = bump.alloc(JSXOpeningFragment {
     inner,
+    span: inner.span(),
     parent: parent.expect::<JSXFragment>(),
   });
   node
@@ -11019,6 +11145,7 @@ pub struct JSXSpreadChild<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXSpreadChild,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -11071,6 +11198,7 @@ impl<'a> CastableNode<'a> for JSXSpreadChild<'a> {
 fn get_view_for_jsxspread_child<'a>(inner: &'a swc_ast::JSXSpreadChild, parent: Node<'a>, bump: &'a Bump) -> &'a JSXSpreadChild<'a> {
   let node = bump.alloc(JSXSpreadChild {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -11086,6 +11214,7 @@ pub struct JSXText<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::JSXText,
+  pub span: Span,
   pub value: &'a swc_atoms::JsWord,
   pub raw: &'a swc_atoms::JsWord,
 }
@@ -11137,6 +11266,7 @@ impl<'a> CastableNode<'a> for JSXText<'a> {
 fn get_view_for_jsxtext<'a>(inner: &'a swc_ast::JSXText, parent: Node<'a>, bump: &'a Bump) -> &'a JSXText<'a> {
   let node = bump.alloc(JSXText {
     inner,
+    span: inner.span(),
     parent,
     value: &inner.value,
     raw: &inner.raw,
@@ -11152,6 +11282,7 @@ pub struct KeyValuePatProp<'a> {
   pub parent: &'a ObjectPat<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::KeyValuePatProp,
+  pub span: Span,
   pub key: PropName<'a>,
   pub value: Pat<'a>,
 }
@@ -11206,6 +11337,7 @@ impl<'a> CastableNode<'a> for KeyValuePatProp<'a> {
 fn get_view_for_key_value_pat_prop<'a>(inner: &'a swc_ast::KeyValuePatProp, parent: Node<'a>, bump: &'a Bump) -> &'a KeyValuePatProp<'a> {
   let node = bump.alloc(KeyValuePatProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ObjectPat>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11223,6 +11355,7 @@ pub struct KeyValueProp<'a> {
   pub parent: &'a ObjectLit<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::KeyValueProp,
+  pub span: Span,
   pub key: PropName<'a>,
   pub value: Expr<'a>,
 }
@@ -11277,6 +11410,7 @@ impl<'a> CastableNode<'a> for KeyValueProp<'a> {
 fn get_view_for_key_value_prop<'a>(inner: &'a swc_ast::KeyValueProp, parent: Node<'a>, bump: &'a Bump) -> &'a KeyValueProp<'a> {
   let node = bump.alloc(KeyValueProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11294,6 +11428,7 @@ pub struct LabeledStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::LabeledStmt,
+  pub span: Span,
   pub label: &'a Ident<'a>,
   pub body: Stmt<'a>,
 }
@@ -11348,6 +11483,7 @@ impl<'a> CastableNode<'a> for LabeledStmt<'a> {
 fn get_view_for_labeled_stmt<'a>(inner: &'a swc_ast::LabeledStmt, parent: Node<'a>, bump: &'a Bump) -> &'a LabeledStmt<'a> {
   let node = bump.alloc(LabeledStmt {
     inner,
+    span: inner.span(),
     parent,
     label: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11365,6 +11501,7 @@ pub struct MemberExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::MemberExpr,
+  pub span: Span,
   pub obj: ExprOrSuper<'a>,
   pub prop: Expr<'a>,
   pub computed: bool,
@@ -11420,6 +11557,7 @@ impl<'a> CastableNode<'a> for MemberExpr<'a> {
 fn get_view_for_member_expr<'a>(inner: &'a swc_ast::MemberExpr, parent: Node<'a>, bump: &'a Bump) -> &'a MemberExpr<'a> {
   let node = bump.alloc(MemberExpr {
     inner,
+    span: inner.span(),
     parent,
     obj: unsafe { MaybeUninit::uninit().assume_init() },
     prop: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11438,6 +11576,7 @@ pub struct MetaPropExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::MetaPropExpr,
+  pub span: Span,
   pub meta: &'a Ident<'a>,
   pub prop: &'a Ident<'a>,
 }
@@ -11492,6 +11631,7 @@ impl<'a> CastableNode<'a> for MetaPropExpr<'a> {
 fn get_view_for_meta_prop_expr<'a>(inner: &'a swc_ast::MetaPropExpr, parent: Node<'a>, bump: &'a Bump) -> &'a MetaPropExpr<'a> {
   let node = bump.alloc(MetaPropExpr {
     inner,
+    span: inner.span(),
     parent,
     meta: unsafe { MaybeUninit::uninit().assume_init() },
     prop: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11509,6 +11649,7 @@ pub struct MethodProp<'a> {
   pub parent: &'a ObjectLit<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::MethodProp,
+  pub span: Span,
   pub key: PropName<'a>,
   pub function: &'a Function<'a>,
 }
@@ -11563,6 +11704,7 @@ impl<'a> CastableNode<'a> for MethodProp<'a> {
 fn get_view_for_method_prop<'a>(inner: &'a swc_ast::MethodProp, parent: Node<'a>, bump: &'a Bump) -> &'a MethodProp<'a> {
   let node = bump.alloc(MethodProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
@@ -11584,6 +11726,7 @@ pub struct Module<'a> {
   pub comments: Option<&'a CommentContainer<'a>>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Module,
+  pub span: Span,
   pub body: Vec<ModuleItem<'a>>,
   pub shebang: &'a Option<swc_atoms::JsWord>,
 }
@@ -11646,6 +11789,7 @@ fn get_view_for_module<'a>(source_file_info: &'a ModuleInfo<'a>, bump: &'a Bump)
   )));
   let node = bump.alloc(Module {
     inner,
+    span: inner.span(),
     source_file: source_file_info.source_file,
     tokens,
     comments,
@@ -11666,6 +11810,7 @@ pub struct NamedExport<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::NamedExport,
+  pub span: Span,
   pub specifiers: Vec<ExportSpecifier<'a>>,
   pub src: Option<&'a Str<'a>>,
   pub asserts: Option<&'a ObjectLit<'a>>,
@@ -11729,6 +11874,7 @@ impl<'a> CastableNode<'a> for NamedExport<'a> {
 fn get_view_for_named_export<'a>(inner: &'a swc_ast::NamedExport, parent: Node<'a>, bump: &'a Bump) -> &'a NamedExport<'a> {
   let node = bump.alloc(NamedExport {
     inner,
+    span: inner.span(),
     parent,
     specifiers: Vec::with_capacity(inner.specifiers.len()),
     src: None,
@@ -11755,6 +11901,7 @@ pub struct NewExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::NewExpr,
+  pub span: Span,
   pub callee: Expr<'a>,
   pub args: Option<Vec<&'a ExprOrSpread<'a>>>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -11817,6 +11964,7 @@ impl<'a> CastableNode<'a> for NewExpr<'a> {
 fn get_view_for_new_expr<'a>(inner: &'a swc_ast::NewExpr, parent: Node<'a>, bump: &'a Bump) -> &'a NewExpr<'a> {
   let node = bump.alloc(NewExpr {
     inner,
+    span: inner.span(),
     parent,
     callee: unsafe { MaybeUninit::uninit().assume_init() },
     args: None,
@@ -11842,6 +11990,7 @@ pub struct Null<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Null,
+  pub span: Span,
 }
 
 impl<'a> Spanned for Null<'a> {
@@ -11891,6 +12040,7 @@ impl<'a> CastableNode<'a> for Null<'a> {
 fn get_view_for_null<'a>(inner: &'a swc_ast::Null, parent: Node<'a>, bump: &'a Bump) -> &'a Null<'a> {
   let node = bump.alloc(Null {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -11903,6 +12053,7 @@ pub struct Number<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Number,
+  pub span: Span,
   /// **Note**: This should not be `NaN`. Use [crate::Ident] to represent NaN.
   ///
   /// If you store `NaN` in this field, a hash map will behave strangely.
@@ -11956,6 +12107,7 @@ impl<'a> CastableNode<'a> for Number<'a> {
 fn get_view_for_number<'a>(inner: &'a swc_ast::Number, parent: Node<'a>, bump: &'a Bump) -> &'a Number<'a> {
   let node = bump.alloc(Number {
     inner,
+    span: inner.span(),
     parent,
     value: inner.value,
   });
@@ -11970,6 +12122,7 @@ pub struct ObjectLit<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ObjectLit,
+  pub span: Span,
   pub props: Vec<PropOrSpread<'a>>,
 }
 
@@ -12024,6 +12177,7 @@ impl<'a> CastableNode<'a> for ObjectLit<'a> {
 fn get_view_for_object_lit<'a>(inner: &'a swc_ast::ObjectLit, parent: Node<'a>, bump: &'a Bump) -> &'a ObjectLit<'a> {
   let node = bump.alloc(ObjectLit {
     inner,
+    span: inner.span(),
     parent,
     props: Vec::with_capacity(inner.props.len()),
   });
@@ -12039,6 +12193,7 @@ pub struct ObjectPat<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ObjectPat,
+  pub span: Span,
   pub props: Vec<ObjectPatProp<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   /// Only in an ambient context
@@ -12099,6 +12254,7 @@ impl<'a> CastableNode<'a> for ObjectPat<'a> {
 fn get_view_for_object_pat<'a>(inner: &'a swc_ast::ObjectPat, parent: Node<'a>, bump: &'a Bump) -> &'a ObjectPat<'a> {
   let node = bump.alloc(ObjectPat {
     inner,
+    span: inner.span(),
     parent,
     props: Vec::with_capacity(inner.props.len()),
     type_ann: None,
@@ -12120,6 +12276,7 @@ pub struct OptChainExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::OptChainExpr,
+  pub span: Span,
   pub expr: Expr<'a>,
   pub question_dot_token: &'a swc_common::Span,
 }
@@ -12173,6 +12330,7 @@ impl<'a> CastableNode<'a> for OptChainExpr<'a> {
 fn get_view_for_opt_chain_expr<'a>(inner: &'a swc_ast::OptChainExpr, parent: Node<'a>, bump: &'a Bump) -> &'a OptChainExpr<'a> {
   let node = bump.alloc(OptChainExpr {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     question_dot_token: &inner.question_dot_token,
@@ -12189,6 +12347,7 @@ pub struct Param<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Param,
+  pub span: Span,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub pat: Pat<'a>,
 }
@@ -12245,6 +12404,7 @@ impl<'a> CastableNode<'a> for Param<'a> {
 fn get_view_for_param<'a>(inner: &'a swc_ast::Param, parent: Node<'a>, bump: &'a Bump) -> &'a Param<'a> {
   let node = bump.alloc(Param {
     inner,
+    span: inner.span(),
     parent,
     decorators: Vec::with_capacity(inner.decorators.len()),
     pat: unsafe { MaybeUninit::uninit().assume_init() },
@@ -12262,6 +12422,7 @@ pub struct ParenExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ParenExpr,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -12314,6 +12475,7 @@ impl<'a> CastableNode<'a> for ParenExpr<'a> {
 fn get_view_for_paren_expr<'a>(inner: &'a swc_ast::ParenExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ParenExpr<'a> {
   let node = bump.alloc(ParenExpr {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -12329,6 +12491,7 @@ pub struct PrivateMethod<'a> {
   pub parent: &'a Class<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::PrivateMethod,
+  pub span: Span,
   pub key: &'a PrivateName<'a>,
   pub function: &'a Function<'a>,
   pub kind: MethodKind,
@@ -12390,6 +12553,7 @@ impl<'a> CastableNode<'a> for PrivateMethod<'a> {
 fn get_view_for_private_method<'a>(inner: &'a swc_ast::PrivateMethod, parent: Node<'a>, bump: &'a Bump) -> &'a PrivateMethod<'a> {
   let node = bump.alloc(PrivateMethod {
     inner,
+    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
@@ -12412,6 +12576,7 @@ pub struct PrivateName<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::PrivateName,
+  pub span: Span,
   pub id: &'a Ident<'a>,
 }
 
@@ -12464,6 +12629,7 @@ impl<'a> CastableNode<'a> for PrivateName<'a> {
 fn get_view_for_private_name<'a>(inner: &'a swc_ast::PrivateName, parent: Node<'a>, bump: &'a Bump) -> &'a PrivateName<'a> {
   let node = bump.alloc(PrivateName {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -12479,6 +12645,7 @@ pub struct PrivateProp<'a> {
   pub parent: &'a Class<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::PrivateProp,
+  pub span: Span,
   pub key: &'a PrivateName<'a>,
   pub value: Option<Expr<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -12552,6 +12719,7 @@ impl<'a> CastableNode<'a> for PrivateProp<'a> {
 fn get_view_for_private_prop<'a>(inner: &'a swc_ast::PrivateProp, parent: Node<'a>, bump: &'a Bump) -> &'a PrivateProp<'a> {
   let node = bump.alloc(PrivateProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     value: None,
@@ -12586,6 +12754,7 @@ pub struct Regex<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Regex,
+  pub span: Span,
   pub exp: &'a swc_atoms::JsWord,
   pub flags: &'a swc_atoms::JsWord,
 }
@@ -12637,6 +12806,7 @@ impl<'a> CastableNode<'a> for Regex<'a> {
 fn get_view_for_regex<'a>(inner: &'a swc_ast::Regex, parent: Node<'a>, bump: &'a Bump) -> &'a Regex<'a> {
   let node = bump.alloc(Regex {
     inner,
+    span: inner.span(),
     parent,
     exp: &inner.exp,
     flags: &inner.flags,
@@ -12652,6 +12822,7 @@ pub struct RestPat<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::RestPat,
+  pub span: Span,
   pub arg: Pat<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub dot3_token: &'a swc_common::Span,
@@ -12709,6 +12880,7 @@ impl<'a> CastableNode<'a> for RestPat<'a> {
 fn get_view_for_rest_pat<'a>(inner: &'a swc_ast::RestPat, parent: Node<'a>, bump: &'a Bump) -> &'a RestPat<'a> {
   let node = bump.alloc(RestPat {
     inner,
+    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
@@ -12730,6 +12902,7 @@ pub struct ReturnStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ReturnStmt,
+  pub span: Span,
   pub arg: Option<Expr<'a>>,
 }
 
@@ -12784,6 +12957,7 @@ impl<'a> CastableNode<'a> for ReturnStmt<'a> {
 fn get_view_for_return_stmt<'a>(inner: &'a swc_ast::ReturnStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ReturnStmt<'a> {
   let node = bump.alloc(ReturnStmt {
     inner,
+    span: inner.span(),
     parent,
     arg: None,
   });
@@ -12806,6 +12980,7 @@ pub struct Script<'a> {
   pub comments: Option<&'a CommentContainer<'a>>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Script,
+  pub span: Span,
   pub body: Vec<Stmt<'a>>,
   pub shebang: &'a Option<swc_atoms::JsWord>,
 }
@@ -12868,6 +13043,7 @@ fn get_view_for_script<'a>(source_file_info: &'a ScriptInfo<'a>, bump: &'a Bump)
   )));
   let node = bump.alloc(Script {
     inner,
+    span: inner.span(),
     source_file: source_file_info.source_file,
     tokens,
     comments,
@@ -12886,6 +13062,7 @@ pub struct SeqExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::SeqExpr,
+  pub span: Span,
   pub exprs: Vec<Expr<'a>>,
 }
 
@@ -12940,6 +13117,7 @@ impl<'a> CastableNode<'a> for SeqExpr<'a> {
 fn get_view_for_seq_expr<'a>(inner: &'a swc_ast::SeqExpr, parent: Node<'a>, bump: &'a Bump) -> &'a SeqExpr<'a> {
   let node = bump.alloc(SeqExpr {
     inner,
+    span: inner.span(),
     parent,
     exprs: Vec::with_capacity(inner.exprs.len()),
   });
@@ -12955,6 +13133,7 @@ pub struct SetterProp<'a> {
   pub parent: &'a ObjectLit<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::SetterProp,
+  pub span: Span,
   pub key: PropName<'a>,
   pub param: Pat<'a>,
   pub body: Option<&'a BlockStmt<'a>>,
@@ -13013,6 +13192,7 @@ impl<'a> CastableNode<'a> for SetterProp<'a> {
 fn get_view_for_setter_prop<'a>(inner: &'a swc_ast::SetterProp, parent: Node<'a>, bump: &'a Bump) -> &'a SetterProp<'a> {
   let node = bump.alloc(SetterProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<ObjectLit>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     param: unsafe { MaybeUninit::uninit().assume_init() },
@@ -13035,6 +13215,7 @@ pub struct SpreadElement<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::SpreadElement,
+  pub span: Span,
   pub expr: Expr<'a>,
   pub dot3_token: &'a swc_common::Span,
 }
@@ -13088,6 +13269,7 @@ impl<'a> CastableNode<'a> for SpreadElement<'a> {
 fn get_view_for_spread_element<'a>(inner: &'a swc_ast::SpreadElement, parent: Node<'a>, bump: &'a Bump) -> &'a SpreadElement<'a> {
   let node = bump.alloc(SpreadElement {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     dot3_token: &inner.dot3_token,
@@ -13104,6 +13286,7 @@ pub struct Str<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Str,
+  pub span: Span,
   pub value: &'a swc_atoms::JsWord,
   /// This includes line escape.
   pub has_escape: bool,
@@ -13157,6 +13340,7 @@ impl<'a> CastableNode<'a> for Str<'a> {
 fn get_view_for_str<'a>(inner: &'a swc_ast::Str, parent: Node<'a>, bump: &'a Bump) -> &'a Str<'a> {
   let node = bump.alloc(Str {
     inner,
+    span: inner.span(),
     parent,
     value: &inner.value,
     has_escape: inner.has_escape,
@@ -13172,6 +13356,7 @@ pub struct Super<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Super,
+  pub span: Span,
 }
 
 impl<'a> Spanned for Super<'a> {
@@ -13221,6 +13406,7 @@ impl<'a> CastableNode<'a> for Super<'a> {
 fn get_view_for_super<'a>(inner: &'a swc_ast::Super, parent: Node<'a>, bump: &'a Bump) -> &'a Super<'a> {
   let node = bump.alloc(Super {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -13233,6 +13419,7 @@ pub struct SwitchCase<'a> {
   pub parent: &'a SwitchStmt<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::SwitchCase,
+  pub span: Span,
   /// None for `default:`
   pub test: Option<Expr<'a>>,
   pub cons: Vec<Stmt<'a>>,
@@ -13292,6 +13479,7 @@ impl<'a> CastableNode<'a> for SwitchCase<'a> {
 fn get_view_for_switch_case<'a>(inner: &'a swc_ast::SwitchCase, parent: Node<'a>, bump: &'a Bump) -> &'a SwitchCase<'a> {
   let node = bump.alloc(SwitchCase {
     inner,
+    span: inner.span(),
     parent: parent.expect::<SwitchStmt>(),
     test: None,
     cons: Vec::with_capacity(inner.cons.len()),
@@ -13312,6 +13500,7 @@ pub struct SwitchStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::SwitchStmt,
+  pub span: Span,
   pub discriminant: Expr<'a>,
   pub cases: Vec<&'a SwitchCase<'a>>,
 }
@@ -13368,6 +13557,7 @@ impl<'a> CastableNode<'a> for SwitchStmt<'a> {
 fn get_view_for_switch_stmt<'a>(inner: &'a swc_ast::SwitchStmt, parent: Node<'a>, bump: &'a Bump) -> &'a SwitchStmt<'a> {
   let node = bump.alloc(SwitchStmt {
     inner,
+    span: inner.span(),
     parent,
     discriminant: unsafe { MaybeUninit::uninit().assume_init() },
     cases: Vec::with_capacity(inner.cases.len()),
@@ -13385,6 +13575,7 @@ pub struct TaggedTpl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TaggedTpl,
+  pub span: Span,
   pub tag: Expr<'a>,
   pub exprs: Vec<Expr<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
@@ -13449,6 +13640,7 @@ impl<'a> CastableNode<'a> for TaggedTpl<'a> {
 fn get_view_for_tagged_tpl<'a>(inner: &'a swc_ast::TaggedTpl, parent: Node<'a>, bump: &'a Bump) -> &'a TaggedTpl<'a> {
   let node = bump.alloc(TaggedTpl {
     inner,
+    span: inner.span(),
     parent,
     tag: unsafe { MaybeUninit::uninit().assume_init() },
     exprs: Vec::with_capacity(inner.exprs.len()),
@@ -13473,6 +13665,7 @@ pub struct ThisExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ThisExpr,
+  pub span: Span,
 }
 
 impl<'a> Spanned for ThisExpr<'a> {
@@ -13522,6 +13715,7 @@ impl<'a> CastableNode<'a> for ThisExpr<'a> {
 fn get_view_for_this_expr<'a>(inner: &'a swc_ast::ThisExpr, parent: Node<'a>, bump: &'a Bump) -> &'a ThisExpr<'a> {
   let node = bump.alloc(ThisExpr {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -13534,6 +13728,7 @@ pub struct ThrowStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::ThrowStmt,
+  pub span: Span,
   pub arg: Expr<'a>,
 }
 
@@ -13586,6 +13781,7 @@ impl<'a> CastableNode<'a> for ThrowStmt<'a> {
 fn get_view_for_throw_stmt<'a>(inner: &'a swc_ast::ThrowStmt, parent: Node<'a>, bump: &'a Bump) -> &'a ThrowStmt<'a> {
   let node = bump.alloc(ThrowStmt {
     inner,
+    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -13601,6 +13797,7 @@ pub struct Tpl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::Tpl,
+  pub span: Span,
   pub exprs: Vec<Expr<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
 }
@@ -13659,6 +13856,7 @@ impl<'a> CastableNode<'a> for Tpl<'a> {
 fn get_view_for_tpl<'a>(inner: &'a swc_ast::Tpl, parent: Node<'a>, bump: &'a Bump) -> &'a Tpl<'a> {
   let node = bump.alloc(Tpl {
     inner,
+    span: inner.span(),
     parent,
     exprs: Vec::with_capacity(inner.exprs.len()),
     quasis: Vec::with_capacity(inner.quasis.len()),
@@ -13676,6 +13874,7 @@ pub struct TplElement<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TplElement,
+  pub span: Span,
   pub cooked: Option<&'a Str<'a>>,
   pub raw: &'a Str<'a>,
   pub tail: bool,
@@ -13733,6 +13932,7 @@ impl<'a> CastableNode<'a> for TplElement<'a> {
 fn get_view_for_tpl_element<'a>(inner: &'a swc_ast::TplElement, parent: Node<'a>, bump: &'a Bump) -> &'a TplElement<'a> {
   let node = bump.alloc(TplElement {
     inner,
+    span: inner.span(),
     parent,
     cooked: None,
     raw: unsafe { MaybeUninit::uninit().assume_init() },
@@ -13754,6 +13954,7 @@ pub struct TryStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TryStmt,
+  pub span: Span,
   pub block: &'a BlockStmt<'a>,
   pub handler: Option<&'a CatchClause<'a>>,
   pub finalizer: Option<&'a BlockStmt<'a>>,
@@ -13814,6 +14015,7 @@ impl<'a> CastableNode<'a> for TryStmt<'a> {
 fn get_view_for_try_stmt<'a>(inner: &'a swc_ast::TryStmt, parent: Node<'a>, bump: &'a Bump) -> &'a TryStmt<'a> {
   let node = bump.alloc(TryStmt {
     inner,
+    span: inner.span(),
     parent,
     block: unsafe { MaybeUninit::uninit().assume_init() },
     handler: None,
@@ -13839,6 +14041,7 @@ pub struct TsArrayType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsArrayType,
+  pub span: Span,
   pub elem_type: TsType<'a>,
 }
 
@@ -13891,6 +14094,7 @@ impl<'a> CastableNode<'a> for TsArrayType<'a> {
 fn get_view_for_ts_array_type<'a>(inner: &'a swc_ast::TsArrayType, parent: Node<'a>, bump: &'a Bump) -> &'a TsArrayType<'a> {
   let node = bump.alloc(TsArrayType {
     inner,
+    span: inner.span(),
     parent,
     elem_type: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -13906,6 +14110,7 @@ pub struct TsAsExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsAsExpr,
+  pub span: Span,
   pub expr: Expr<'a>,
   pub type_ann: TsType<'a>,
 }
@@ -13960,6 +14165,7 @@ impl<'a> CastableNode<'a> for TsAsExpr<'a> {
 fn get_view_for_ts_as_expr<'a>(inner: &'a swc_ast::TsAsExpr, parent: Node<'a>, bump: &'a Bump) -> &'a TsAsExpr<'a> {
   let node = bump.alloc(TsAsExpr {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
@@ -13977,6 +14183,7 @@ pub struct TsCallSignatureDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsCallSignatureDecl,
+  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -14039,6 +14246,7 @@ impl<'a> CastableNode<'a> for TsCallSignatureDecl<'a> {
 fn get_view_for_ts_call_signature_decl<'a>(inner: &'a swc_ast::TsCallSignatureDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsCallSignatureDecl<'a> {
   let node = bump.alloc(TsCallSignatureDecl {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
@@ -14064,6 +14272,7 @@ pub struct TsConditionalType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsConditionalType,
+  pub span: Span,
   pub check_type: TsType<'a>,
   pub extends_type: TsType<'a>,
   pub true_type: TsType<'a>,
@@ -14122,6 +14331,7 @@ impl<'a> CastableNode<'a> for TsConditionalType<'a> {
 fn get_view_for_ts_conditional_type<'a>(inner: &'a swc_ast::TsConditionalType, parent: Node<'a>, bump: &'a Bump) -> &'a TsConditionalType<'a> {
   let node = bump.alloc(TsConditionalType {
     inner,
+    span: inner.span(),
     parent,
     check_type: unsafe { MaybeUninit::uninit().assume_init() },
     extends_type: unsafe { MaybeUninit::uninit().assume_init() },
@@ -14143,6 +14353,7 @@ pub struct TsConstAssertion<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsConstAssertion,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -14195,6 +14406,7 @@ impl<'a> CastableNode<'a> for TsConstAssertion<'a> {
 fn get_view_for_ts_const_assertion<'a>(inner: &'a swc_ast::TsConstAssertion, parent: Node<'a>, bump: &'a Bump) -> &'a TsConstAssertion<'a> {
   let node = bump.alloc(TsConstAssertion {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -14210,6 +14422,7 @@ pub struct TsConstructSignatureDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsConstructSignatureDecl,
+  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -14272,6 +14485,7 @@ impl<'a> CastableNode<'a> for TsConstructSignatureDecl<'a> {
 fn get_view_for_ts_construct_signature_decl<'a>(inner: &'a swc_ast::TsConstructSignatureDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsConstructSignatureDecl<'a> {
   let node = bump.alloc(TsConstructSignatureDecl {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
@@ -14297,6 +14511,7 @@ pub struct TsConstructorType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsConstructorType,
+  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: &'a TsTypeAnn<'a>,
@@ -14358,6 +14573,7 @@ impl<'a> CastableNode<'a> for TsConstructorType<'a> {
 fn get_view_for_ts_constructor_type<'a>(inner: &'a swc_ast::TsConstructorType, parent: Node<'a>, bump: &'a Bump) -> &'a TsConstructorType<'a> {
   let node = bump.alloc(TsConstructorType {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_params: None,
@@ -14381,6 +14597,7 @@ pub struct TsEnumDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsEnumDecl,
+  pub span: Span,
   pub id: &'a Ident<'a>,
   pub members: Vec<&'a TsEnumMember<'a>>,
   pub declare: bool,
@@ -14439,6 +14656,7 @@ impl<'a> CastableNode<'a> for TsEnumDecl<'a> {
 fn get_view_for_ts_enum_decl<'a>(inner: &'a swc_ast::TsEnumDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsEnumDecl<'a> {
   let node = bump.alloc(TsEnumDecl {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     members: Vec::with_capacity(inner.members.len()),
@@ -14458,6 +14676,7 @@ pub struct TsEnumMember<'a> {
   pub parent: &'a TsEnumDecl<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsEnumMember,
+  pub span: Span,
   pub id: TsEnumMemberId<'a>,
   pub init: Option<Expr<'a>>,
 }
@@ -14514,6 +14733,7 @@ impl<'a> CastableNode<'a> for TsEnumMember<'a> {
 fn get_view_for_ts_enum_member<'a>(inner: &'a swc_ast::TsEnumMember, parent: Node<'a>, bump: &'a Bump) -> &'a TsEnumMember<'a> {
   let node = bump.alloc(TsEnumMember {
     inner,
+    span: inner.span(),
     parent: parent.expect::<TsEnumDecl>(),
     id: unsafe { MaybeUninit::uninit().assume_init() },
     init: None,
@@ -14537,6 +14757,7 @@ pub struct TsExportAssignment<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsExportAssignment,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -14589,6 +14810,7 @@ impl<'a> CastableNode<'a> for TsExportAssignment<'a> {
 fn get_view_for_ts_export_assignment<'a>(inner: &'a swc_ast::TsExportAssignment, parent: Node<'a>, bump: &'a Bump) -> &'a TsExportAssignment<'a> {
   let node = bump.alloc(TsExportAssignment {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -14604,6 +14826,7 @@ pub struct TsExprWithTypeArgs<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsExprWithTypeArgs,
+  pub span: Span,
   pub expr: TsEntityName<'a>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
 }
@@ -14660,6 +14883,7 @@ impl<'a> CastableNode<'a> for TsExprWithTypeArgs<'a> {
 fn get_view_for_ts_expr_with_type_args<'a>(inner: &'a swc_ast::TsExprWithTypeArgs, parent: Node<'a>, bump: &'a Bump) -> &'a TsExprWithTypeArgs<'a> {
   let node = bump.alloc(TsExprWithTypeArgs {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     type_args: None,
@@ -14680,6 +14904,7 @@ pub struct TsExternalModuleRef<'a> {
   pub parent: &'a TsImportEqualsDecl<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsExternalModuleRef,
+  pub span: Span,
   pub expr: &'a Str<'a>,
 }
 
@@ -14732,6 +14957,7 @@ impl<'a> CastableNode<'a> for TsExternalModuleRef<'a> {
 fn get_view_for_ts_external_module_ref<'a>(inner: &'a swc_ast::TsExternalModuleRef, parent: Node<'a>, bump: &'a Bump) -> &'a TsExternalModuleRef<'a> {
   let node = bump.alloc(TsExternalModuleRef {
     inner,
+    span: inner.span(),
     parent: parent.expect::<TsImportEqualsDecl>(),
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -14747,6 +14973,7 @@ pub struct TsFnType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsFnType,
+  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: &'a TsTypeAnn<'a>,
@@ -14807,6 +15034,7 @@ impl<'a> CastableNode<'a> for TsFnType<'a> {
 fn get_view_for_ts_fn_type<'a>(inner: &'a swc_ast::TsFnType, parent: Node<'a>, bump: &'a Bump) -> &'a TsFnType<'a> {
   let node = bump.alloc(TsFnType {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_params: None,
@@ -14829,6 +15057,7 @@ pub struct TsImportEqualsDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsImportEqualsDecl,
+  pub span: Span,
   pub id: &'a Ident<'a>,
   pub module_ref: TsModuleRef<'a>,
   pub declare: bool,
@@ -14885,6 +15114,7 @@ impl<'a> CastableNode<'a> for TsImportEqualsDecl<'a> {
 fn get_view_for_ts_import_equals_decl<'a>(inner: &'a swc_ast::TsImportEqualsDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsImportEqualsDecl<'a> {
   let node = bump.alloc(TsImportEqualsDecl {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     module_ref: unsafe { MaybeUninit::uninit().assume_init() },
@@ -14904,6 +15134,7 @@ pub struct TsImportType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsImportType,
+  pub span: Span,
   pub arg: &'a Str<'a>,
   pub qualifier: Option<TsEntityName<'a>>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -14964,6 +15195,7 @@ impl<'a> CastableNode<'a> for TsImportType<'a> {
 fn get_view_for_ts_import_type<'a>(inner: &'a swc_ast::TsImportType, parent: Node<'a>, bump: &'a Bump) -> &'a TsImportType<'a> {
   let node = bump.alloc(TsImportType {
     inner,
+    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
     qualifier: None,
@@ -14989,6 +15221,7 @@ pub struct TsIndexSignature<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsIndexSignature,
+  pub span: Span,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub readonly: bool,
@@ -15048,6 +15281,7 @@ impl<'a> CastableNode<'a> for TsIndexSignature<'a> {
 fn get_view_for_ts_index_signature<'a>(inner: &'a swc_ast::TsIndexSignature, parent: Node<'a>, bump: &'a Bump) -> &'a TsIndexSignature<'a> {
   let node = bump.alloc(TsIndexSignature {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
@@ -15069,6 +15303,7 @@ pub struct TsIndexedAccessType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsIndexedAccessType,
+  pub span: Span,
   pub obj_type: TsType<'a>,
   pub index_type: TsType<'a>,
   pub readonly: bool,
@@ -15124,6 +15359,7 @@ impl<'a> CastableNode<'a> for TsIndexedAccessType<'a> {
 fn get_view_for_ts_indexed_access_type<'a>(inner: &'a swc_ast::TsIndexedAccessType, parent: Node<'a>, bump: &'a Bump) -> &'a TsIndexedAccessType<'a> {
   let node = bump.alloc(TsIndexedAccessType {
     inner,
+    span: inner.span(),
     parent,
     obj_type: unsafe { MaybeUninit::uninit().assume_init() },
     index_type: unsafe { MaybeUninit::uninit().assume_init() },
@@ -15142,6 +15378,7 @@ pub struct TsInferType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsInferType,
+  pub span: Span,
   pub type_param: &'a TsTypeParam<'a>,
 }
 
@@ -15194,6 +15431,7 @@ impl<'a> CastableNode<'a> for TsInferType<'a> {
 fn get_view_for_ts_infer_type<'a>(inner: &'a swc_ast::TsInferType, parent: Node<'a>, bump: &'a Bump) -> &'a TsInferType<'a> {
   let node = bump.alloc(TsInferType {
     inner,
+    span: inner.span(),
     parent,
     type_param: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -15209,6 +15447,7 @@ pub struct TsInterfaceBody<'a> {
   pub parent: &'a TsInterfaceDecl<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsInterfaceBody,
+  pub span: Span,
   pub body: Vec<TsTypeElement<'a>>,
 }
 
@@ -15263,6 +15502,7 @@ impl<'a> CastableNode<'a> for TsInterfaceBody<'a> {
 fn get_view_for_ts_interface_body<'a>(inner: &'a swc_ast::TsInterfaceBody, parent: Node<'a>, bump: &'a Bump) -> &'a TsInterfaceBody<'a> {
   let node = bump.alloc(TsInterfaceBody {
     inner,
+    span: inner.span(),
     parent: parent.expect::<TsInterfaceDecl>(),
     body: Vec::with_capacity(inner.body.len()),
   });
@@ -15278,6 +15518,7 @@ pub struct TsInterfaceDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsInterfaceDecl,
+  pub span: Span,
   pub id: &'a Ident<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub extends: Vec<&'a TsExprWithTypeArgs<'a>>,
@@ -15341,6 +15582,7 @@ impl<'a> CastableNode<'a> for TsInterfaceDecl<'a> {
 fn get_view_for_ts_interface_decl<'a>(inner: &'a swc_ast::TsInterfaceDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsInterfaceDecl<'a> {
   let node = bump.alloc(TsInterfaceDecl {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
@@ -15366,6 +15608,7 @@ pub struct TsIntersectionType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsIntersectionType,
+  pub span: Span,
   pub types: Vec<TsType<'a>>,
 }
 
@@ -15420,6 +15663,7 @@ impl<'a> CastableNode<'a> for TsIntersectionType<'a> {
 fn get_view_for_ts_intersection_type<'a>(inner: &'a swc_ast::TsIntersectionType, parent: Node<'a>, bump: &'a Bump) -> &'a TsIntersectionType<'a> {
   let node = bump.alloc(TsIntersectionType {
     inner,
+    span: inner.span(),
     parent,
     types: Vec::with_capacity(inner.types.len()),
   });
@@ -15435,6 +15679,7 @@ pub struct TsKeywordType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsKeywordType,
+  pub span: Span,
   pub kind: TsKeywordTypeKind,
 }
 
@@ -15485,6 +15730,7 @@ impl<'a> CastableNode<'a> for TsKeywordType<'a> {
 fn get_view_for_ts_keyword_type<'a>(inner: &'a swc_ast::TsKeywordType, parent: Node<'a>, bump: &'a Bump) -> &'a TsKeywordType<'a> {
   let node = bump.alloc(TsKeywordType {
     inner,
+    span: inner.span(),
     parent,
     kind: inner.kind,
   });
@@ -15498,6 +15744,7 @@ pub struct TsLitType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsLitType,
+  pub span: Span,
   pub lit: TsLit<'a>,
 }
 
@@ -15550,6 +15797,7 @@ impl<'a> CastableNode<'a> for TsLitType<'a> {
 fn get_view_for_ts_lit_type<'a>(inner: &'a swc_ast::TsLitType, parent: Node<'a>, bump: &'a Bump) -> &'a TsLitType<'a> {
   let node = bump.alloc(TsLitType {
     inner,
+    span: inner.span(),
     parent,
     lit: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -15565,6 +15813,7 @@ pub struct TsMappedType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsMappedType,
+  pub span: Span,
   pub type_param: &'a TsTypeParam<'a>,
   pub name_type: Option<TsType<'a>>,
   pub type_ann: Option<TsType<'a>>,
@@ -15627,6 +15876,7 @@ impl<'a> CastableNode<'a> for TsMappedType<'a> {
 fn get_view_for_ts_mapped_type<'a>(inner: &'a swc_ast::TsMappedType, parent: Node<'a>, bump: &'a Bump) -> &'a TsMappedType<'a> {
   let node = bump.alloc(TsMappedType {
     inner,
+    span: inner.span(),
     parent,
     type_param: unsafe { MaybeUninit::uninit().assume_init() },
     name_type: None,
@@ -15654,6 +15904,7 @@ pub struct TsMethodSignature<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsMethodSignature,
+  pub span: Span,
   pub key: Expr<'a>,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -15721,6 +15972,7 @@ impl<'a> CastableNode<'a> for TsMethodSignature<'a> {
 fn get_view_for_ts_method_signature<'a>(inner: &'a swc_ast::TsMethodSignature, parent: Node<'a>, bump: &'a Bump) -> &'a TsMethodSignature<'a> {
   let node = bump.alloc(TsMethodSignature {
     inner,
+    span: inner.span(),
     parent,
     key: unsafe { MaybeUninit::uninit().assume_init() },
     params: Vec::with_capacity(inner.params.len()),
@@ -15751,6 +16003,7 @@ pub struct TsModuleBlock<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsModuleBlock,
+  pub span: Span,
   pub body: Vec<ModuleItem<'a>>,
 }
 
@@ -15805,6 +16058,7 @@ impl<'a> CastableNode<'a> for TsModuleBlock<'a> {
 fn get_view_for_ts_module_block<'a>(inner: &'a swc_ast::TsModuleBlock, parent: Node<'a>, bump: &'a Bump) -> &'a TsModuleBlock<'a> {
   let node = bump.alloc(TsModuleBlock {
     inner,
+    span: inner.span(),
     parent,
     body: Vec::with_capacity(inner.body.len()),
   });
@@ -15820,6 +16074,7 @@ pub struct TsModuleDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsModuleDecl,
+  pub span: Span,
   pub id: TsModuleName<'a>,
   pub body: Option<TsNamespaceBody<'a>>,
   pub declare: bool,
@@ -15879,6 +16134,7 @@ impl<'a> CastableNode<'a> for TsModuleDecl<'a> {
 fn get_view_for_ts_module_decl<'a>(inner: &'a swc_ast::TsModuleDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsModuleDecl<'a> {
   let node = bump.alloc(TsModuleDecl {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     body: None,
@@ -15901,6 +16157,7 @@ pub struct TsNamespaceDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsNamespaceDecl,
+  pub span: Span,
   pub id: &'a Ident<'a>,
   pub body: TsNamespaceBody<'a>,
   pub declare: bool,
@@ -15958,6 +16215,7 @@ impl<'a> CastableNode<'a> for TsNamespaceDecl<'a> {
 fn get_view_for_ts_namespace_decl<'a>(inner: &'a swc_ast::TsNamespaceDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsNamespaceDecl<'a> {
   let node = bump.alloc(TsNamespaceDecl {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -15977,6 +16235,7 @@ pub struct TsNamespaceExportDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsNamespaceExportDecl,
+  pub span: Span,
   pub id: &'a Ident<'a>,
 }
 
@@ -16029,6 +16288,7 @@ impl<'a> CastableNode<'a> for TsNamespaceExportDecl<'a> {
 fn get_view_for_ts_namespace_export_decl<'a>(inner: &'a swc_ast::TsNamespaceExportDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsNamespaceExportDecl<'a> {
   let node = bump.alloc(TsNamespaceExportDecl {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16044,6 +16304,7 @@ pub struct TsNonNullExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsNonNullExpr,
+  pub span: Span,
   pub expr: Expr<'a>,
 }
 
@@ -16096,6 +16357,7 @@ impl<'a> CastableNode<'a> for TsNonNullExpr<'a> {
 fn get_view_for_ts_non_null_expr<'a>(inner: &'a swc_ast::TsNonNullExpr, parent: Node<'a>, bump: &'a Bump) -> &'a TsNonNullExpr<'a> {
   let node = bump.alloc(TsNonNullExpr {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16111,6 +16373,7 @@ pub struct TsOptionalType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsOptionalType,
+  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -16163,6 +16426,7 @@ impl<'a> CastableNode<'a> for TsOptionalType<'a> {
 fn get_view_for_ts_optional_type<'a>(inner: &'a swc_ast::TsOptionalType, parent: Node<'a>, bump: &'a Bump) -> &'a TsOptionalType<'a> {
   let node = bump.alloc(TsOptionalType {
     inner,
+    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16178,6 +16442,7 @@ pub struct TsParamProp<'a> {
   pub parent: &'a Constructor<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsParamProp,
+  pub span: Span,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub param: TsParamPropParam<'a>,
   /// At least one of `accessibility` or `readonly` must be set.
@@ -16237,6 +16502,7 @@ impl<'a> CastableNode<'a> for TsParamProp<'a> {
 fn get_view_for_ts_param_prop<'a>(inner: &'a swc_ast::TsParamProp, parent: Node<'a>, bump: &'a Bump) -> &'a TsParamProp<'a> {
   let node = bump.alloc(TsParamProp {
     inner,
+    span: inner.span(),
     parent: parent.expect::<Constructor>(),
     decorators: Vec::with_capacity(inner.decorators.len()),
     param: unsafe { MaybeUninit::uninit().assume_init() },
@@ -16256,6 +16522,7 @@ pub struct TsParenthesizedType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsParenthesizedType,
+  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -16308,6 +16575,7 @@ impl<'a> CastableNode<'a> for TsParenthesizedType<'a> {
 fn get_view_for_ts_parenthesized_type<'a>(inner: &'a swc_ast::TsParenthesizedType, parent: Node<'a>, bump: &'a Bump) -> &'a TsParenthesizedType<'a> {
   let node = bump.alloc(TsParenthesizedType {
     inner,
+    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16323,6 +16591,7 @@ pub struct TsPropertySignature<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsPropertySignature,
+  pub span: Span,
   pub key: Expr<'a>,
   pub init: Option<Expr<'a>>,
   pub params: Vec<TsFnParam<'a>>,
@@ -16394,6 +16663,7 @@ impl<'a> CastableNode<'a> for TsPropertySignature<'a> {
 fn get_view_for_ts_property_signature<'a>(inner: &'a swc_ast::TsPropertySignature, parent: Node<'a>, bump: &'a Bump) -> &'a TsPropertySignature<'a> {
   let node = bump.alloc(TsPropertySignature {
     inner,
+    span: inner.span(),
     parent,
     key: unsafe { MaybeUninit::uninit().assume_init() },
     init: None,
@@ -16429,6 +16699,7 @@ pub struct TsQualifiedName<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsQualifiedName,
+  pub span: Span,
   pub left: TsEntityName<'a>,
   pub right: &'a Ident<'a>,
 }
@@ -16483,6 +16754,7 @@ impl<'a> CastableNode<'a> for TsQualifiedName<'a> {
 fn get_view_for_ts_qualified_name<'a>(inner: &'a swc_ast::TsQualifiedName, parent: Node<'a>, bump: &'a Bump) -> &'a TsQualifiedName<'a> {
   let node = bump.alloc(TsQualifiedName {
     inner,
+    span: inner.span(),
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
@@ -16500,6 +16772,7 @@ pub struct TsRestType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsRestType,
+  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -16552,6 +16825,7 @@ impl<'a> CastableNode<'a> for TsRestType<'a> {
 fn get_view_for_ts_rest_type<'a>(inner: &'a swc_ast::TsRestType, parent: Node<'a>, bump: &'a Bump) -> &'a TsRestType<'a> {
   let node = bump.alloc(TsRestType {
     inner,
+    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16567,6 +16841,7 @@ pub struct TsThisType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsThisType,
+  pub span: Span,
 }
 
 impl<'a> Spanned for TsThisType<'a> {
@@ -16616,6 +16891,7 @@ impl<'a> CastableNode<'a> for TsThisType<'a> {
 fn get_view_for_ts_this_type<'a>(inner: &'a swc_ast::TsThisType, parent: Node<'a>, bump: &'a Bump) -> &'a TsThisType<'a> {
   let node = bump.alloc(TsThisType {
     inner,
+    span: inner.span(),
     parent,
   });
   node
@@ -16628,6 +16904,7 @@ pub struct TsTplLitType<'a> {
   pub parent: &'a TsLitType<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTplLitType,
+  pub span: Span,
   pub types: Vec<TsType<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
 }
@@ -16686,6 +16963,7 @@ impl<'a> CastableNode<'a> for TsTplLitType<'a> {
 fn get_view_for_ts_tpl_lit_type<'a>(inner: &'a swc_ast::TsTplLitType, parent: Node<'a>, bump: &'a Bump) -> &'a TsTplLitType<'a> {
   let node = bump.alloc(TsTplLitType {
     inner,
+    span: inner.span(),
     parent: parent.expect::<TsLitType>(),
     types: Vec::with_capacity(inner.types.len()),
     quasis: Vec::with_capacity(inner.quasis.len()),
@@ -16703,6 +16981,7 @@ pub struct TsTupleElement<'a> {
   pub parent: &'a TsTupleType<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTupleElement,
+  pub span: Span,
   /// `Ident` or `RestPat { arg: Ident }`
   pub label: Option<Pat<'a>>,
   pub ty: TsType<'a>,
@@ -16760,6 +17039,7 @@ impl<'a> CastableNode<'a> for TsTupleElement<'a> {
 fn get_view_for_ts_tuple_element<'a>(inner: &'a swc_ast::TsTupleElement, parent: Node<'a>, bump: &'a Bump) -> &'a TsTupleElement<'a> {
   let node = bump.alloc(TsTupleElement {
     inner,
+    span: inner.span(),
     parent: parent.expect::<TsTupleType>(),
     label: None,
     ty: unsafe { MaybeUninit::uninit().assume_init() },
@@ -16780,6 +17060,7 @@ pub struct TsTupleType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTupleType,
+  pub span: Span,
   pub elem_types: Vec<&'a TsTupleElement<'a>>,
 }
 
@@ -16834,6 +17115,7 @@ impl<'a> CastableNode<'a> for TsTupleType<'a> {
 fn get_view_for_ts_tuple_type<'a>(inner: &'a swc_ast::TsTupleType, parent: Node<'a>, bump: &'a Bump) -> &'a TsTupleType<'a> {
   let node = bump.alloc(TsTupleType {
     inner,
+    span: inner.span(),
     parent,
     elem_types: Vec::with_capacity(inner.elem_types.len()),
   });
@@ -16849,6 +17131,7 @@ pub struct TsTypeAliasDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAliasDecl,
+  pub span: Span,
   pub id: &'a Ident<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: TsType<'a>,
@@ -16908,6 +17191,7 @@ impl<'a> CastableNode<'a> for TsTypeAliasDecl<'a> {
 fn get_view_for_ts_type_alias_decl<'a>(inner: &'a swc_ast::TsTypeAliasDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeAliasDecl<'a> {
   let node = bump.alloc(TsTypeAliasDecl {
     inner,
+    span: inner.span(),
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
@@ -16931,6 +17215,7 @@ pub struct TsTypeAnn<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAnn,
+  pub span: Span,
   pub type_ann: TsType<'a>,
 }
 
@@ -16983,6 +17268,7 @@ impl<'a> CastableNode<'a> for TsTypeAnn<'a> {
 fn get_view_for_ts_type_ann<'a>(inner: &'a swc_ast::TsTypeAnn, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeAnn<'a> {
   let node = bump.alloc(TsTypeAnn {
     inner,
+    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -16998,6 +17284,7 @@ pub struct TsTypeAssertion<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAssertion,
+  pub span: Span,
   pub expr: Expr<'a>,
   pub type_ann: TsType<'a>,
 }
@@ -17052,6 +17339,7 @@ impl<'a> CastableNode<'a> for TsTypeAssertion<'a> {
 fn get_view_for_ts_type_assertion<'a>(inner: &'a swc_ast::TsTypeAssertion, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeAssertion<'a> {
   let node = bump.alloc(TsTypeAssertion {
     inner,
+    span: inner.span(),
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
@@ -17069,6 +17357,7 @@ pub struct TsTypeLit<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeLit,
+  pub span: Span,
   pub members: Vec<TsTypeElement<'a>>,
 }
 
@@ -17123,6 +17412,7 @@ impl<'a> CastableNode<'a> for TsTypeLit<'a> {
 fn get_view_for_ts_type_lit<'a>(inner: &'a swc_ast::TsTypeLit, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeLit<'a> {
   let node = bump.alloc(TsTypeLit {
     inner,
+    span: inner.span(),
     parent,
     members: Vec::with_capacity(inner.members.len()),
   });
@@ -17138,6 +17428,7 @@ pub struct TsTypeOperator<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeOperator,
+  pub span: Span,
   pub type_ann: TsType<'a>,
   pub op: TsTypeOperatorOp,
 }
@@ -17191,6 +17482,7 @@ impl<'a> CastableNode<'a> for TsTypeOperator<'a> {
 fn get_view_for_ts_type_operator<'a>(inner: &'a swc_ast::TsTypeOperator, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeOperator<'a> {
   let node = bump.alloc(TsTypeOperator {
     inner,
+    span: inner.span(),
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
     op: inner.op,
@@ -17207,6 +17499,7 @@ pub struct TsTypeParam<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParam,
+  pub span: Span,
   pub name: &'a Ident<'a>,
   pub constraint: Option<TsType<'a>>,
   pub default: Option<TsType<'a>>,
@@ -17267,6 +17560,7 @@ impl<'a> CastableNode<'a> for TsTypeParam<'a> {
 fn get_view_for_ts_type_param<'a>(inner: &'a swc_ast::TsTypeParam, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeParam<'a> {
   let node = bump.alloc(TsTypeParam {
     inner,
+    span: inner.span(),
     parent,
     name: unsafe { MaybeUninit::uninit().assume_init() },
     constraint: None,
@@ -17292,6 +17586,7 @@ pub struct TsTypeParamDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParamDecl,
+  pub span: Span,
   pub params: Vec<&'a TsTypeParam<'a>>,
 }
 
@@ -17346,6 +17641,7 @@ impl<'a> CastableNode<'a> for TsTypeParamDecl<'a> {
 fn get_view_for_ts_type_param_decl<'a>(inner: &'a swc_ast::TsTypeParamDecl, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeParamDecl<'a> {
   let node = bump.alloc(TsTypeParamDecl {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
   });
@@ -17361,6 +17657,7 @@ pub struct TsTypeParamInstantiation<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParamInstantiation,
+  pub span: Span,
   pub params: Vec<TsType<'a>>,
 }
 
@@ -17415,6 +17712,7 @@ impl<'a> CastableNode<'a> for TsTypeParamInstantiation<'a> {
 fn get_view_for_ts_type_param_instantiation<'a>(inner: &'a swc_ast::TsTypeParamInstantiation, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeParamInstantiation<'a> {
   let node = bump.alloc(TsTypeParamInstantiation {
     inner,
+    span: inner.span(),
     parent,
     params: Vec::with_capacity(inner.params.len()),
   });
@@ -17430,6 +17728,7 @@ pub struct TsTypePredicate<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypePredicate,
+  pub span: Span,
   pub param_name: TsThisTypeOrIdent<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub asserts: bool,
@@ -17487,6 +17786,7 @@ impl<'a> CastableNode<'a> for TsTypePredicate<'a> {
 fn get_view_for_ts_type_predicate<'a>(inner: &'a swc_ast::TsTypePredicate, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypePredicate<'a> {
   let node = bump.alloc(TsTypePredicate {
     inner,
+    span: inner.span(),
     parent,
     param_name: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
@@ -17509,6 +17809,7 @@ pub struct TsTypeQuery<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeQuery,
+  pub span: Span,
   pub expr_name: TsTypeQueryExpr<'a>,
 }
 
@@ -17561,6 +17862,7 @@ impl<'a> CastableNode<'a> for TsTypeQuery<'a> {
 fn get_view_for_ts_type_query<'a>(inner: &'a swc_ast::TsTypeQuery, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeQuery<'a> {
   let node = bump.alloc(TsTypeQuery {
     inner,
+    span: inner.span(),
     parent,
     expr_name: unsafe { MaybeUninit::uninit().assume_init() },
   });
@@ -17576,6 +17878,7 @@ pub struct TsTypeRef<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeRef,
+  pub span: Span,
   pub type_name: TsEntityName<'a>,
   pub type_params: Option<&'a TsTypeParamInstantiation<'a>>,
 }
@@ -17632,6 +17935,7 @@ impl<'a> CastableNode<'a> for TsTypeRef<'a> {
 fn get_view_for_ts_type_ref<'a>(inner: &'a swc_ast::TsTypeRef, parent: Node<'a>, bump: &'a Bump) -> &'a TsTypeRef<'a> {
   let node = bump.alloc(TsTypeRef {
     inner,
+    span: inner.span(),
     parent,
     type_name: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
@@ -17652,6 +17956,7 @@ pub struct TsUnionType<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::TsUnionType,
+  pub span: Span,
   pub types: Vec<TsType<'a>>,
 }
 
@@ -17706,6 +18011,7 @@ impl<'a> CastableNode<'a> for TsUnionType<'a> {
 fn get_view_for_ts_union_type<'a>(inner: &'a swc_ast::TsUnionType, parent: Node<'a>, bump: &'a Bump) -> &'a TsUnionType<'a> {
   let node = bump.alloc(TsUnionType {
     inner,
+    span: inner.span(),
     parent,
     types: Vec::with_capacity(inner.types.len()),
   });
@@ -17721,6 +18027,7 @@ pub struct UnaryExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::UnaryExpr,
+  pub span: Span,
   pub arg: Expr<'a>,
   pub op: UnaryOp,
 }
@@ -17774,6 +18081,7 @@ impl<'a> CastableNode<'a> for UnaryExpr<'a> {
 fn get_view_for_unary_expr<'a>(inner: &'a swc_ast::UnaryExpr, parent: Node<'a>, bump: &'a Bump) -> &'a UnaryExpr<'a> {
   let node = bump.alloc(UnaryExpr {
     inner,
+    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
     op: inner.op,
@@ -17790,6 +18098,7 @@ pub struct UpdateExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::UpdateExpr,
+  pub span: Span,
   pub arg: Expr<'a>,
   pub op: UpdateOp,
   pub prefix: bool,
@@ -17844,6 +18153,7 @@ impl<'a> CastableNode<'a> for UpdateExpr<'a> {
 fn get_view_for_update_expr<'a>(inner: &'a swc_ast::UpdateExpr, parent: Node<'a>, bump: &'a Bump) -> &'a UpdateExpr<'a> {
   let node = bump.alloc(UpdateExpr {
     inner,
+    span: inner.span(),
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
     op: inner.op,
@@ -17861,6 +18171,7 @@ pub struct VarDecl<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::VarDecl,
+  pub span: Span,
   pub decls: Vec<&'a VarDeclarator<'a>>,
   pub kind: VarDeclKind,
   pub declare: bool,
@@ -17917,6 +18228,7 @@ impl<'a> CastableNode<'a> for VarDecl<'a> {
 fn get_view_for_var_decl<'a>(inner: &'a swc_ast::VarDecl, parent: Node<'a>, bump: &'a Bump) -> &'a VarDecl<'a> {
   let node = bump.alloc(VarDecl {
     inner,
+    span: inner.span(),
     parent,
     decls: Vec::with_capacity(inner.decls.len()),
     kind: inner.kind,
@@ -17934,6 +18246,7 @@ pub struct VarDeclarator<'a> {
   pub parent: &'a VarDecl<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::VarDeclarator,
+  pub span: Span,
   pub name: Pat<'a>,
   /// Initialization expression.
   pub init: Option<Expr<'a>>,
@@ -17993,6 +18306,7 @@ impl<'a> CastableNode<'a> for VarDeclarator<'a> {
 fn get_view_for_var_declarator<'a>(inner: &'a swc_ast::VarDeclarator, parent: Node<'a>, bump: &'a Bump) -> &'a VarDeclarator<'a> {
   let node = bump.alloc(VarDeclarator {
     inner,
+    span: inner.span(),
     parent: parent.expect::<VarDecl>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
     init: None,
@@ -18014,6 +18328,7 @@ pub struct WhileStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::WhileStmt,
+  pub span: Span,
   pub test: Expr<'a>,
   pub body: Stmt<'a>,
 }
@@ -18068,6 +18383,7 @@ impl<'a> CastableNode<'a> for WhileStmt<'a> {
 fn get_view_for_while_stmt<'a>(inner: &'a swc_ast::WhileStmt, parent: Node<'a>, bump: &'a Bump) -> &'a WhileStmt<'a> {
   let node = bump.alloc(WhileStmt {
     inner,
+    span: inner.span(),
     parent,
     test: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -18085,6 +18401,7 @@ pub struct WithStmt<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::WithStmt,
+  pub span: Span,
   pub obj: Expr<'a>,
   pub body: Stmt<'a>,
 }
@@ -18139,6 +18456,7 @@ impl<'a> CastableNode<'a> for WithStmt<'a> {
 fn get_view_for_with_stmt<'a>(inner: &'a swc_ast::WithStmt, parent: Node<'a>, bump: &'a Bump) -> &'a WithStmt<'a> {
   let node = bump.alloc(WithStmt {
     inner,
+    span: inner.span(),
     parent,
     obj: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
@@ -18156,6 +18474,7 @@ pub struct YieldExpr<'a> {
   pub parent: Node<'a>,
   #[serde(skip)]
   pub inner: &'a swc_ast::YieldExpr,
+  pub span: Span,
   pub arg: Option<Expr<'a>>,
   pub delegate: bool,
 }
@@ -18211,6 +18530,7 @@ impl<'a> CastableNode<'a> for YieldExpr<'a> {
 fn get_view_for_yield_expr<'a>(inner: &'a swc_ast::YieldExpr, parent: Node<'a>, bump: &'a Bump) -> &'a YieldExpr<'a> {
   let node = bump.alloc(YieldExpr {
     inner,
+    span: inner.span(),
     parent,
     arg: None,
     delegate: inner.delegate,

--- a/rs-lib/src/generated.rs
+++ b/rs-lib/src/generated.rs
@@ -2,6 +2,7 @@
 // Run `deno run -A generation/main.ts` from the root directory to regenerate it.
 use std::mem::{self, MaybeUninit};
 use bumpalo::Bump;
+use serde::Serialize;
 use swc_common::{Span, Spanned};
 pub use swc_ecmascript::ast::{self as swc_ast, Accessibility, AssignOp, BinaryOp, EsVersion, MethodKind, StrKind, TruePlusMinus, TsKeywordTypeKind, TsTypeOperatorOp, UnaryOp, UpdateOp, VarDeclKind};
 use crate::comments::*;
@@ -1400,7 +1401,8 @@ impl std::fmt::Display for NodeKind {
 }
 
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum BlockStmtOrExpr<'a> {
   BlockStmt(&'a BlockStmt<'a>),
   Expr(Expr<'a>),
@@ -1489,7 +1491,8 @@ fn get_view_for_block_stmt_or_expr<'a>(inner: &'a swc_ast::BlockStmtOrExpr, pare
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ClassMember<'a> {
   Constructor(&'a Constructor<'a>),
   /// `es2015`
@@ -1625,7 +1628,8 @@ fn get_view_for_class_member<'a>(inner: &'a swc_ast::ClassMember, parent: Node<'
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum Decl<'a> {
   Class(&'a ClassDecl<'a>),
   Fn(&'a FnDecl<'a>),
@@ -1759,7 +1763,8 @@ fn get_view_for_decl<'a>(inner: &'a swc_ast::Decl, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum DefaultDecl<'a> {
   Class(&'a ClassExpr<'a>),
   Fn(&'a FnExpr<'a>),
@@ -1857,7 +1862,8 @@ fn get_view_for_default_decl<'a>(inner: &'a swc_ast::DefaultDecl, parent: Node<'
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ExportSpecifier<'a> {
   Namespace(&'a ExportNamespaceSpecifier<'a>),
   Default(&'a ExportDefaultSpecifier<'a>),
@@ -1955,7 +1961,8 @@ fn get_view_for_export_specifier<'a>(inner: &'a swc_ast::ExportSpecifier, parent
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum Expr<'a> {
   This(&'a ThisExpr<'a>),
   Array(&'a ArrayLit<'a>),
@@ -2348,7 +2355,8 @@ fn get_view_for_expr<'a>(inner: &'a swc_ast::Expr, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ExprOrSuper<'a> {
   Super(&'a Super<'a>),
   Expr(Expr<'a>),
@@ -2437,7 +2445,8 @@ fn get_view_for_expr_or_super<'a>(inner: &'a swc_ast::ExprOrSuper, parent: Node<
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ImportSpecifier<'a> {
   Named(&'a ImportNamedSpecifier<'a>),
   Default(&'a ImportDefaultSpecifier<'a>),
@@ -2535,7 +2544,8 @@ fn get_view_for_import_specifier<'a>(inner: &'a swc_ast::ImportSpecifier, parent
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum JSXAttrName<'a> {
   Ident(&'a Ident<'a>),
   JSXNamespacedName(&'a JSXNamespacedName<'a>),
@@ -2624,7 +2634,8 @@ fn get_view_for_jsxattr_name<'a>(inner: &'a swc_ast::JSXAttrName, parent: Node<'
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum JSXAttrOrSpread<'a> {
   JSXAttr(&'a JSXAttr<'a>),
   SpreadElement(&'a SpreadElement<'a>),
@@ -2713,7 +2724,8 @@ fn get_view_for_jsxattr_or_spread<'a>(inner: &'a swc_ast::JSXAttrOrSpread, paren
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum JSXAttrValue<'a> {
   Lit(Lit<'a>),
   JSXExprContainer(&'a JSXExprContainer<'a>),
@@ -2820,7 +2832,8 @@ fn get_view_for_jsxattr_value<'a>(inner: &'a swc_ast::JSXAttrValue, parent: Node
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum JSXElementChild<'a> {
   JSXText(&'a JSXText<'a>),
   JSXExprContainer(&'a JSXExprContainer<'a>),
@@ -2936,7 +2949,8 @@ fn get_view_for_jsxelement_child<'a>(inner: &'a swc_ast::JSXElementChild, parent
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum JSXElementName<'a> {
   Ident(&'a Ident<'a>),
   JSXMemberExpr(&'a JSXMemberExpr<'a>),
@@ -3034,7 +3048,8 @@ fn get_view_for_jsxelement_name<'a>(inner: &'a swc_ast::JSXElementName, parent: 
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum JSXExpr<'a> {
   JSXEmptyExpr(&'a JSXEmptyExpr<'a>),
   Expr(Expr<'a>),
@@ -3124,7 +3139,8 @@ fn get_view_for_jsxexpr<'a>(inner: &'a swc_ast::JSXExpr, parent: Node<'a>, bump:
 }
 
 /// Used for `obj` property of `JSXMemberExpr`.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum JSXObject<'a> {
   JSXMemberExpr(&'a JSXMemberExpr<'a>),
   Ident(&'a Ident<'a>),
@@ -3213,7 +3229,8 @@ fn get_view_for_jsxobject<'a>(inner: &'a swc_ast::JSXObject, parent: Node<'a>, b
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum Lit<'a> {
   Str(&'a Str<'a>),
   Bool(&'a Bool<'a>),
@@ -3347,7 +3364,8 @@ fn get_view_for_lit<'a>(inner: &'a swc_ast::Lit, parent: Node<'a>, bump: &'a Bum
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ModuleDecl<'a> {
   Import(&'a ImportDecl<'a>),
   ExportDecl(&'a ExportDecl<'a>),
@@ -3499,7 +3517,8 @@ fn get_view_for_module_decl<'a>(inner: &'a swc_ast::ModuleDecl, parent: Node<'a>
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ModuleItem<'a> {
   ModuleDecl(ModuleDecl<'a>),
   Stmt(Stmt<'a>),
@@ -3588,7 +3607,8 @@ fn get_view_for_module_item<'a>(inner: &'a swc_ast::ModuleItem, parent: Node<'a>
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ObjectPatProp<'a> {
   KeyValue(&'a KeyValuePatProp<'a>),
   Assign(&'a AssignPatProp<'a>),
@@ -3686,7 +3706,8 @@ fn get_view_for_object_pat_prop<'a>(inner: &'a swc_ast::ObjectPatProp, parent: N
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum ParamOrTsParamProp<'a> {
   TsParamProp(&'a TsParamProp<'a>),
   Param(&'a Param<'a>),
@@ -3775,7 +3796,8 @@ fn get_view_for_param_or_ts_param_prop<'a>(inner: &'a swc_ast::ParamOrTsParamPro
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum Pat<'a> {
   Ident(&'a BindingIdent<'a>),
   Array(&'a ArrayPat<'a>),
@@ -3910,7 +3932,8 @@ fn get_view_for_pat<'a>(inner: &'a swc_ast::Pat, parent: Node<'a>, bump: &'a Bum
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum PatOrExpr<'a> {
   Expr(Expr<'a>),
   Pat(Pat<'a>),
@@ -3999,7 +4022,8 @@ fn get_view_for_pat_or_expr<'a>(inner: &'a swc_ast::PatOrExpr, parent: Node<'a>,
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum Prop<'a> {
   /// `a` in `{ a, }`
   Shorthand(&'a Ident<'a>),
@@ -4127,7 +4151,8 @@ fn get_view_for_prop<'a>(inner: &'a swc_ast::Prop, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum PropName<'a> {
   Ident(&'a Ident<'a>),
   /// String literal.
@@ -4245,7 +4270,8 @@ fn get_view_for_prop_name<'a>(inner: &'a swc_ast::PropName, parent: Node<'a>, bu
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum PropOrSpread<'a> {
   /// Spread properties, e.g., `{a: 1, ...obj, b: 2}`.
   Spread(&'a SpreadElement<'a>),
@@ -4335,7 +4361,8 @@ fn get_view_for_prop_or_spread<'a>(inner: &'a swc_ast::PropOrSpread, parent: Nod
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum Stmt<'a> {
   Block(&'a BlockStmt<'a>),
   Empty(&'a EmptyStmt<'a>),
@@ -4578,7 +4605,8 @@ fn get_view_for_stmt<'a>(inner: &'a swc_ast::Stmt, parent: Node<'a>, bump: &'a B
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsEntityName<'a> {
   TsQualifiedName(&'a TsQualifiedName<'a>),
   Ident(&'a Ident<'a>),
@@ -4669,7 +4697,8 @@ fn get_view_for_ts_entity_name<'a>(inner: &'a swc_ast::TsEntityName, parent: Nod
 
 ///
 /// - Invalid: [Ident] with empty symbol.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsEnumMemberId<'a> {
   Ident(&'a Ident<'a>),
   Str(&'a Str<'a>),
@@ -4758,7 +4787,8 @@ fn get_view_for_ts_enum_member_id<'a>(inner: &'a swc_ast::TsEnumMemberId, parent
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsFnOrConstructorType<'a> {
   TsFnType(&'a TsFnType<'a>),
   TsConstructorType(&'a TsConstructorType<'a>),
@@ -4847,7 +4877,8 @@ fn get_view_for_ts_fn_or_constructor_type<'a>(inner: &'a swc_ast::TsFnOrConstruc
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsFnParam<'a> {
   Ident(&'a BindingIdent<'a>),
   Array(&'a ArrayPat<'a>),
@@ -4954,7 +4985,8 @@ fn get_view_for_ts_fn_param<'a>(inner: &'a swc_ast::TsFnParam, parent: Node<'a>,
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsLit<'a> {
   Number(&'a Number<'a>),
   Str(&'a Str<'a>),
@@ -5070,7 +5102,8 @@ fn get_view_for_ts_lit<'a>(inner: &'a swc_ast::TsLit, parent: Node<'a>, bump: &'
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsModuleName<'a> {
   Ident(&'a Ident<'a>),
   Str(&'a Str<'a>),
@@ -5159,7 +5192,8 @@ fn get_view_for_ts_module_name<'a>(inner: &'a swc_ast::TsModuleName, parent: Nod
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsModuleRef<'a> {
   TsEntityName(TsEntityName<'a>),
   TsExternalModuleRef(&'a TsExternalModuleRef<'a>),
@@ -5250,7 +5284,8 @@ fn get_view_for_ts_module_ref<'a>(inner: &'a swc_ast::TsModuleRef, parent: Node<
 
 /// `namespace A.B { }` is a namespace named `A` with another TsNamespaceDecl as
 /// its body.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsNamespaceBody<'a> {
   TsModuleBlock(&'a TsModuleBlock<'a>),
   TsNamespaceDecl(&'a TsNamespaceDecl<'a>),
@@ -5339,7 +5374,8 @@ fn get_view_for_ts_namespace_body<'a>(inner: &'a swc_ast::TsNamespaceBody, paren
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsParamPropParam<'a> {
   Ident(&'a BindingIdent<'a>),
   Assign(&'a AssignPat<'a>),
@@ -5428,7 +5464,8 @@ fn get_view_for_ts_param_prop_param<'a>(inner: &'a swc_ast::TsParamPropParam, pa
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsThisTypeOrIdent<'a> {
   TsThisType(&'a TsThisType<'a>),
   Ident(&'a Ident<'a>),
@@ -5517,7 +5554,8 @@ fn get_view_for_ts_this_type_or_ident<'a>(inner: &'a swc_ast::TsThisTypeOrIdent,
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsType<'a> {
   TsKeywordType(&'a TsKeywordType<'a>),
   TsThisType(&'a TsThisType<'a>),
@@ -5768,7 +5806,8 @@ fn get_view_for_ts_type<'a>(inner: &'a swc_ast::TsType, parent: Node<'a>, bump: 
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsTypeElement<'a> {
   TsCallSignatureDecl(&'a TsCallSignatureDecl<'a>),
   TsConstructSignatureDecl(&'a TsConstructSignatureDecl<'a>),
@@ -5884,7 +5923,8 @@ fn get_view_for_ts_type_element<'a>(inner: &'a swc_ast::TsTypeElement, parent: N
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsTypeQueryExpr<'a> {
   TsEntityName(TsEntityName<'a>),
   Import(&'a TsImportType<'a>),
@@ -5973,7 +6013,8 @@ fn get_view_for_ts_type_query_expr<'a>(inner: &'a swc_ast::TsTypeQueryExpr, pare
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TsUnionOrIntersectionType<'a> {
   TsUnionType(&'a TsUnionType<'a>),
   TsIntersectionType(&'a TsIntersectionType<'a>),
@@ -6062,7 +6103,8 @@ fn get_view_for_ts_union_or_intersection_type<'a>(inner: &'a swc_ast::TsUnionOrI
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum VarDeclOrExpr<'a> {
   VarDecl(&'a VarDecl<'a>),
   Expr(Expr<'a>),
@@ -6151,7 +6193,8 @@ fn get_view_for_var_decl_or_expr<'a>(inner: &'a swc_ast::VarDeclOrExpr, parent: 
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
+#[serde(untagged)]
 pub enum VarDeclOrPat<'a> {
   VarDecl(&'a VarDecl<'a>),
   Pat(Pat<'a>),
@@ -6241,8 +6284,12 @@ fn get_view_for_var_decl_or_pat<'a>(inner: &'a swc_ast::VarDeclOrPat, parent: No
 }
 
 /// Array literal.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ArrayLit<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ArrayLit,
   pub elems: Vec<Option<&'a ExprOrSpread<'a>>>,
 }
@@ -6311,8 +6358,12 @@ fn get_view_for_array_lit<'a>(inner: &'a swc_ast::ArrayLit, parent: Node<'a>, bu
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ArrayPat<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ArrayPat,
   pub elems: Vec<Option<Pat<'a>>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -6393,8 +6444,12 @@ fn get_view_for_array_pat<'a>(inner: &'a swc_ast::ArrayPat, parent: Node<'a>, bu
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ArrowExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ArrowExpr,
   pub params: Vec<Pat<'a>>,
   pub body: BlockStmtOrExpr<'a>,
@@ -6484,8 +6539,12 @@ fn get_view_for_arrow_expr<'a>(inner: &'a swc_ast::ArrowExpr, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct AssignExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::AssignExpr,
   pub left: PatOrExpr<'a>,
   pub right: Expr<'a>,
@@ -6553,8 +6612,12 @@ fn get_view_for_assign_expr<'a>(inner: &'a swc_ast::AssignExpr, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct AssignPat<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::AssignPat,
   pub left: Pat<'a>,
   pub right: Expr<'a>,
@@ -6630,8 +6693,12 @@ fn get_view_for_assign_pat<'a>(inner: &'a swc_ast::AssignPat, parent: Node<'a>, 
 }
 
 /// `{key}` or `{key = value}`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct AssignPatProp<'a> {
+  #[serde(skip)]
   pub parent: &'a ObjectPat<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::AssignPatProp,
   pub key: &'a Ident<'a>,
   pub value: Option<Expr<'a>>,
@@ -6702,8 +6769,12 @@ fn get_view_for_assign_pat_prop<'a>(inner: &'a swc_ast::AssignPatProp, parent: N
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct AssignProp<'a> {
+  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::AssignProp,
   pub key: &'a Ident<'a>,
   pub value: Expr<'a>,
@@ -6769,8 +6840,12 @@ fn get_view_for_assign_prop<'a>(inner: &'a swc_ast::AssignProp, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct AwaitExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::AwaitExpr,
   pub arg: Expr<'a>,
 }
@@ -6832,8 +6907,12 @@ fn get_view_for_await_expr<'a>(inner: &'a swc_ast::AwaitExpr, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct BigInt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::BigInt,
   pub value: &'a num_bigint::BigInt,
 }
@@ -6891,8 +6970,12 @@ fn get_view_for_big_int<'a>(inner: &'a swc_ast::BigInt, parent: Node<'a>, bump: 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct BinExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::BinExpr,
   pub left: Expr<'a>,
   pub right: Expr<'a>,
@@ -6961,8 +7044,12 @@ fn get_view_for_bin_expr<'a>(inner: &'a swc_ast::BinExpr, parent: Node<'a>, bump
 }
 
 /// Identifer used as a pattern.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct BindingIdent<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::BindingIdent,
   pub id: &'a Ident<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -7034,8 +7121,12 @@ fn get_view_for_binding_ident<'a>(inner: &'a swc_ast::BindingIdent, parent: Node
 }
 
 /// Use when only block statements are allowed.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct BlockStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::BlockStmt,
   pub stmts: Vec<Stmt<'a>>,
 }
@@ -7099,8 +7190,12 @@ fn get_view_for_block_stmt<'a>(inner: &'a swc_ast::BlockStmt, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Bool<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Bool,
   pub value: bool,
 }
@@ -7158,8 +7253,12 @@ fn get_view_for_bool<'a>(inner: &'a swc_ast::Bool, parent: Node<'a>, bump: &'a B
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct BreakStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::BreakStmt,
   pub label: Option<&'a Ident<'a>>,
 }
@@ -7226,8 +7325,12 @@ fn get_view_for_break_stmt<'a>(inner: &'a swc_ast::BreakStmt, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct CallExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::CallExpr,
   pub callee: ExprOrSuper<'a>,
   pub args: Vec<&'a ExprOrSpread<'a>>,
@@ -7304,8 +7407,12 @@ fn get_view_for_call_expr<'a>(inner: &'a swc_ast::CallExpr, parent: Node<'a>, bu
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct CatchClause<'a> {
+  #[serde(skip)]
   pub parent: &'a TryStmt<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::CatchClause,
   /// es2019
   ///
@@ -7380,8 +7487,12 @@ fn get_view_for_catch_clause<'a>(inner: &'a swc_ast::CatchClause, parent: Node<'
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Class<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Class,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub body: Vec<ClassMember<'a>>,
@@ -7487,8 +7598,12 @@ fn get_view_for_class<'a>(inner: &'a swc_ast::Class, parent: Node<'a>, bump: &'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ClassDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ClassDecl,
   pub ident: &'a Ident<'a>,
   pub class: &'a Class<'a>,
@@ -7557,8 +7672,12 @@ fn get_view_for_class_decl<'a>(inner: &'a swc_ast::ClassDecl, parent: Node<'a>, 
 }
 
 /// Class expression.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ClassExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ClassExpr,
   pub ident: Option<&'a Ident<'a>>,
   pub class: &'a Class<'a>,
@@ -7629,8 +7748,12 @@ fn get_view_for_class_expr<'a>(inner: &'a swc_ast::ClassExpr, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ClassMethod<'a> {
+  #[serde(skip)]
   pub parent: &'a Class<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ClassMethod,
   pub key: PropName<'a>,
   pub function: &'a Function<'a>,
@@ -7708,8 +7831,12 @@ fn get_view_for_class_method<'a>(inner: &'a swc_ast::ClassMethod, parent: Node<'
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ClassProp<'a> {
+  #[serde(skip)]
   pub parent: &'a Class<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ClassProp,
   pub key: Expr<'a>,
   pub value: Option<Expr<'a>>,
@@ -7813,8 +7940,12 @@ fn get_view_for_class_prop<'a>(inner: &'a swc_ast::ClassProp, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ComputedPropName<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ComputedPropName,
   pub expr: Expr<'a>,
 }
@@ -7876,8 +8007,12 @@ fn get_view_for_computed_prop_name<'a>(inner: &'a swc_ast::ComputedPropName, par
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct CondExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::CondExpr,
   pub test: Expr<'a>,
   pub cons: Expr<'a>,
@@ -7947,8 +8082,12 @@ fn get_view_for_cond_expr<'a>(inner: &'a swc_ast::CondExpr, parent: Node<'a>, bu
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Constructor<'a> {
+  #[serde(skip)]
   pub parent: &'a Class<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Constructor,
   pub key: PropName<'a>,
   pub params: Vec<ParamOrTsParamProp<'a>>,
@@ -8029,8 +8168,12 @@ fn get_view_for_constructor<'a>(inner: &'a swc_ast::Constructor, parent: Node<'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ContinueStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ContinueStmt,
   pub label: Option<&'a Ident<'a>>,
 }
@@ -8097,8 +8240,12 @@ fn get_view_for_continue_stmt<'a>(inner: &'a swc_ast::ContinueStmt, parent: Node
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct DebuggerStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::DebuggerStmt,
 }
 
@@ -8154,8 +8301,12 @@ fn get_view_for_debugger_stmt<'a>(inner: &'a swc_ast::DebuggerStmt, parent: Node
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Decorator<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Decorator,
   pub expr: Expr<'a>,
 }
@@ -8217,8 +8368,12 @@ fn get_view_for_decorator<'a>(inner: &'a swc_ast::Decorator, parent: Node<'a>, b
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct DoWhileStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::DoWhileStmt,
   pub test: Expr<'a>,
   pub body: Stmt<'a>,
@@ -8284,8 +8439,12 @@ fn get_view_for_do_while_stmt<'a>(inner: &'a swc_ast::DoWhileStmt, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct EmptyStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::EmptyStmt,
 }
 
@@ -8342,8 +8501,12 @@ fn get_view_for_empty_stmt<'a>(inner: &'a swc_ast::EmptyStmt, parent: Node<'a>, 
 }
 
 /// `export * from 'mod'`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExportAll<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExportAll,
   pub src: &'a Str<'a>,
   pub asserts: Option<&'a ObjectLit<'a>>,
@@ -8414,8 +8577,12 @@ fn get_view_for_export_all<'a>(inner: &'a swc_ast::ExportAll, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExportDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDecl,
   pub decl: Decl<'a>,
 }
@@ -8477,8 +8644,12 @@ fn get_view_for_export_decl<'a>(inner: &'a swc_ast::ExportDecl, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExportDefaultDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultDecl,
   pub decl: DefaultDecl<'a>,
 }
@@ -8540,8 +8711,12 @@ fn get_view_for_export_default_decl<'a>(inner: &'a swc_ast::ExportDefaultDecl, p
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExportDefaultExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultExpr,
   pub expr: Expr<'a>,
 }
@@ -8603,8 +8778,12 @@ fn get_view_for_export_default_expr<'a>(inner: &'a swc_ast::ExportDefaultExpr, p
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExportDefaultSpecifier<'a> {
+  #[serde(skip)]
   pub parent: &'a NamedExport<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExportDefaultSpecifier,
   pub exported: &'a Ident<'a>,
 }
@@ -8666,8 +8845,12 @@ fn get_view_for_export_default_specifier<'a>(inner: &'a swc_ast::ExportDefaultSp
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExportNamedSpecifier<'a> {
+  #[serde(skip)]
   pub parent: &'a NamedExport<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExportNamedSpecifier,
   /// `foo` in `export { foo as bar }`
   pub orig: &'a Ident<'a>,
@@ -8741,8 +8924,12 @@ fn get_view_for_export_named_specifier<'a>(inner: &'a swc_ast::ExportNamedSpecif
 }
 
 /// `export * as foo from 'src';`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExportNamespaceSpecifier<'a> {
+  #[serde(skip)]
   pub parent: &'a NamedExport<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExportNamespaceSpecifier,
   pub name: &'a Ident<'a>,
 }
@@ -8804,8 +8991,12 @@ fn get_view_for_export_namespace_specifier<'a>(inner: &'a swc_ast::ExportNamespa
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExprOrSpread<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExprOrSpread,
   pub expr: Expr<'a>,
   pub spread: &'a Option<swc_common::Span>,
@@ -8869,8 +9060,12 @@ fn get_view_for_expr_or_spread<'a>(inner: &'a swc_ast::ExprOrSpread, parent: Nod
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ExprStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ExprStmt,
   pub expr: Expr<'a>,
 }
@@ -8932,8 +9127,12 @@ fn get_view_for_expr_stmt<'a>(inner: &'a swc_ast::ExprStmt, parent: Node<'a>, bu
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct FnDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::FnDecl,
   pub ident: &'a Ident<'a>,
   pub function: &'a Function<'a>,
@@ -9002,8 +9201,12 @@ fn get_view_for_fn_decl<'a>(inner: &'a swc_ast::FnDecl, parent: Node<'a>, bump: 
 }
 
 /// Function expression.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct FnExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::FnExpr,
   pub ident: Option<&'a Ident<'a>>,
   pub function: &'a Function<'a>,
@@ -9074,8 +9277,12 @@ fn get_view_for_fn_expr<'a>(inner: &'a swc_ast::FnExpr, parent: Node<'a>, bump: 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ForInStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ForInStmt,
   pub left: VarDeclOrPat<'a>,
   pub right: Expr<'a>,
@@ -9145,8 +9352,12 @@ fn get_view_for_for_in_stmt<'a>(inner: &'a swc_ast::ForInStmt, parent: Node<'a>,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ForOfStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ForOfStmt,
   pub left: VarDeclOrPat<'a>,
   pub right: Expr<'a>,
@@ -9223,8 +9434,12 @@ fn get_view_for_for_of_stmt<'a>(inner: &'a swc_ast::ForOfStmt, parent: Node<'a>,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ForStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ForStmt,
   pub init: Option<VarDeclOrExpr<'a>>,
   pub test: Option<Expr<'a>>,
@@ -9314,8 +9529,12 @@ fn get_view_for_for_stmt<'a>(inner: &'a swc_ast::ForStmt, parent: Node<'a>, bump
 }
 
 /// Common parts of function and method.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Function<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Function,
   pub params: Vec<&'a Param<'a>>,
   pub decorators: Vec<&'a Decorator<'a>>,
@@ -9418,8 +9637,12 @@ fn get_view_for_function<'a>(inner: &'a swc_ast::Function, parent: Node<'a>, bum
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct GetterProp<'a> {
+  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::GetterProp,
   pub key: PropName<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -9500,8 +9723,12 @@ fn get_view_for_getter_prop<'a>(inner: &'a swc_ast::GetterProp, parent: Node<'a>
 }
 
 /// Ident with span.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Ident<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Ident,
   pub sym: &'a swc_atoms::JsWord,
   /// TypeScript only. Used in case of an optional parameter.
@@ -9562,8 +9789,12 @@ fn get_view_for_ident<'a>(inner: &'a swc_ast::Ident, parent: Node<'a>, bump: &'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct IfStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::IfStmt,
   pub test: Expr<'a>,
   pub cons: Stmt<'a>,
@@ -9638,8 +9869,12 @@ fn get_view_for_if_stmt<'a>(inner: &'a swc_ast::IfStmt, parent: Node<'a>, bump: 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ImportDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ImportDecl,
   pub specifiers: Vec<ImportSpecifier<'a>>,
   pub src: &'a Str<'a>,
@@ -9719,8 +9954,12 @@ fn get_view_for_import_decl<'a>(inner: &'a swc_ast::ImportDecl, parent: Node<'a>
 }
 
 /// e.g. `import foo from 'mod.js'`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ImportDefaultSpecifier<'a> {
+  #[serde(skip)]
   pub parent: &'a ImportDecl<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ImportDefaultSpecifier,
   pub local: &'a Ident<'a>,
 }
@@ -9785,8 +10024,12 @@ fn get_view_for_import_default_specifier<'a>(inner: &'a swc_ast::ImportDefaultSp
 /// e.g. local = foo, imported = None `import { foo } from 'mod.js'`
 /// e.g. local = bar, imported = Some(foo) for `import { foo as bar } from
 /// 'mod.js'`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ImportNamedSpecifier<'a> {
+  #[serde(skip)]
   pub parent: &'a ImportDecl<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ImportNamedSpecifier,
   pub local: &'a Ident<'a>,
   pub imported: Option<&'a Ident<'a>>,
@@ -9858,8 +10101,12 @@ fn get_view_for_import_named_specifier<'a>(inner: &'a swc_ast::ImportNamedSpecif
 }
 
 /// e.g. `import * as foo from 'mod.js'`.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ImportStarAsSpecifier<'a> {
+  #[serde(skip)]
   pub parent: &'a ImportDecl<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ImportStarAsSpecifier,
   pub local: &'a Ident<'a>,
 }
@@ -9922,8 +10169,12 @@ fn get_view_for_import_star_as_specifier<'a>(inner: &'a swc_ast::ImportStarAsSpe
 }
 
 /// Represents a invalid node.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Invalid<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Invalid,
 }
 
@@ -9979,8 +10230,12 @@ fn get_view_for_invalid<'a>(inner: &'a swc_ast::Invalid, parent: Node<'a>, bump:
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXAttr<'a> {
+  #[serde(skip)]
   pub parent: &'a JSXOpeningElement<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXAttr,
   pub name: JSXAttrName<'a>,
   /// Babel uses Expr instead of JSXAttrValue
@@ -10052,8 +10307,12 @@ fn get_view_for_jsxattr<'a>(inner: &'a swc_ast::JSXAttr, parent: Node<'a>, bump:
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXClosingElement<'a> {
+  #[serde(skip)]
   pub parent: &'a JSXElement<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXClosingElement,
   pub name: JSXElementName<'a>,
 }
@@ -10115,8 +10374,12 @@ fn get_view_for_jsxclosing_element<'a>(inner: &'a swc_ast::JSXClosingElement, pa
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXClosingFragment<'a> {
+  #[serde(skip)]
   pub parent: &'a JSXFragment<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXClosingFragment,
 }
 
@@ -10172,8 +10435,12 @@ fn get_view_for_jsxclosing_fragment<'a>(inner: &'a swc_ast::JSXClosingFragment, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXElement<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXElement,
   pub opening: &'a JSXOpeningElement<'a>,
   pub children: Vec<JSXElementChild<'a>>,
@@ -10250,8 +10517,12 @@ fn get_view_for_jsxelement<'a>(inner: &'a swc_ast::JSXElement, parent: Node<'a>,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXEmptyExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXEmptyExpr,
 }
 
@@ -10307,8 +10578,12 @@ fn get_view_for_jsxempty_expr<'a>(inner: &'a swc_ast::JSXEmptyExpr, parent: Node
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXExprContainer<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXExprContainer,
   pub expr: JSXExpr<'a>,
 }
@@ -10370,8 +10645,12 @@ fn get_view_for_jsxexpr_container<'a>(inner: &'a swc_ast::JSXExprContainer, pare
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXFragment<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXFragment,
   pub opening: &'a JSXOpeningFragment<'a>,
   pub children: Vec<JSXElementChild<'a>>,
@@ -10443,8 +10722,12 @@ fn get_view_for_jsxfragment<'a>(inner: &'a swc_ast::JSXFragment, parent: Node<'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXMemberExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXMemberExpr,
   pub obj: JSXObject<'a>,
   pub prop: &'a Ident<'a>,
@@ -10511,8 +10794,12 @@ fn get_view_for_jsxmember_expr<'a>(inner: &'a swc_ast::JSXMemberExpr, parent: No
 }
 
 /// XML-based namespace syntax:
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXNamespacedName<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXNamespacedName,
   pub ns: &'a Ident<'a>,
   pub name: &'a Ident<'a>,
@@ -10578,8 +10865,12 @@ fn get_view_for_jsxnamespaced_name<'a>(inner: &'a swc_ast::JSXNamespacedName, pa
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXOpeningElement<'a> {
+  #[serde(skip)]
   pub parent: &'a JSXElement<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXOpeningElement,
   pub name: JSXElementName<'a>,
   pub attrs: Vec<JSXAttrOrSpread<'a>>,
@@ -10660,8 +10951,12 @@ fn get_view_for_jsxopening_element<'a>(inner: &'a swc_ast::JSXOpeningElement, pa
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXOpeningFragment<'a> {
+  #[serde(skip)]
   pub parent: &'a JSXFragment<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXOpeningFragment,
 }
 
@@ -10717,8 +11012,12 @@ fn get_view_for_jsxopening_fragment<'a>(inner: &'a swc_ast::JSXOpeningFragment, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXSpreadChild<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXSpreadChild,
   pub expr: Expr<'a>,
 }
@@ -10780,8 +11079,12 @@ fn get_view_for_jsxspread_child<'a>(inner: &'a swc_ast::JSXSpreadChild, parent: 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct JSXText<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::JSXText,
   pub value: &'a swc_atoms::JsWord,
   pub raw: &'a swc_atoms::JsWord,
@@ -10842,8 +11145,12 @@ fn get_view_for_jsxtext<'a>(inner: &'a swc_ast::JSXText, parent: Node<'a>, bump:
 }
 
 /// `{key: value}`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct KeyValuePatProp<'a> {
+  #[serde(skip)]
   pub parent: &'a ObjectPat<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::KeyValuePatProp,
   pub key: PropName<'a>,
   pub value: Pat<'a>,
@@ -10909,8 +11216,12 @@ fn get_view_for_key_value_pat_prop<'a>(inner: &'a swc_ast::KeyValuePatProp, pare
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct KeyValueProp<'a> {
+  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::KeyValueProp,
   pub key: PropName<'a>,
   pub value: Expr<'a>,
@@ -10976,8 +11287,12 @@ fn get_view_for_key_value_prop<'a>(inner: &'a swc_ast::KeyValueProp, parent: Nod
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct LabeledStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::LabeledStmt,
   pub label: &'a Ident<'a>,
   pub body: Stmt<'a>,
@@ -11043,8 +11358,12 @@ fn get_view_for_labeled_stmt<'a>(inner: &'a swc_ast::LabeledStmt, parent: Node<'
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct MemberExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::MemberExpr,
   pub obj: ExprOrSuper<'a>,
   pub prop: Expr<'a>,
@@ -11112,8 +11431,12 @@ fn get_view_for_member_expr<'a>(inner: &'a swc_ast::MemberExpr, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct MetaPropExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::MetaPropExpr,
   pub meta: &'a Ident<'a>,
   pub prop: &'a Ident<'a>,
@@ -11179,8 +11502,12 @@ fn get_view_for_meta_prop_expr<'a>(inner: &'a swc_ast::MetaPropExpr, parent: Nod
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct MethodProp<'a> {
+  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::MethodProp,
   pub key: PropName<'a>,
   pub function: &'a Function<'a>,
@@ -11246,10 +11573,16 @@ fn get_view_for_method_prop<'a>(inner: &'a swc_ast::MethodProp, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Module<'a> {
+  #[serde(skip)]
   pub source_file: Option<&'a swc_common::SourceFile>,
+  #[serde(skip)]
   pub tokens: Option<&'a TokenContainer<'a>>,
+  #[serde(skip)]
   pub comments: Option<&'a CommentContainer<'a>>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Module,
   pub body: Vec<ModuleItem<'a>>,
   pub shebang: &'a Option<swc_atoms::JsWord>,
@@ -11326,8 +11659,12 @@ fn get_view_for_module<'a>(source_file_info: &'a ModuleInfo<'a>, bump: &'a Bump)
 
 /// `export { foo } from 'mod'`
 /// `export { foo as bar } from 'mod'`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct NamedExport<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::NamedExport,
   pub specifiers: Vec<ExportSpecifier<'a>>,
   pub src: Option<&'a Str<'a>>,
@@ -11411,8 +11748,12 @@ fn get_view_for_named_export<'a>(inner: &'a swc_ast::NamedExport, parent: Node<'
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct NewExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::NewExpr,
   pub callee: Expr<'a>,
   pub args: Option<Vec<&'a ExprOrSpread<'a>>>,
@@ -11494,8 +11835,12 @@ fn get_view_for_new_expr<'a>(inner: &'a swc_ast::NewExpr, parent: Node<'a>, bump
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Null<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Null,
 }
 
@@ -11551,8 +11896,12 @@ fn get_view_for_null<'a>(inner: &'a swc_ast::Null, parent: Node<'a>, bump: &'a B
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Number<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Number,
   /// **Note**: This should not be `NaN`. Use [crate::Ident] to represent NaN.
   ///
@@ -11614,8 +11963,12 @@ fn get_view_for_number<'a>(inner: &'a swc_ast::Number, parent: Node<'a>, bump: &
 }
 
 /// Object literal.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ObjectLit<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ObjectLit,
   pub props: Vec<PropOrSpread<'a>>,
 }
@@ -11679,8 +12032,12 @@ fn get_view_for_object_lit<'a>(inner: &'a swc_ast::ObjectLit, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ObjectPat<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ObjectPat,
   pub props: Vec<ObjectPatProp<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -11756,8 +12113,12 @@ fn get_view_for_object_pat<'a>(inner: &'a swc_ast::ObjectPat, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct OptChainExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::OptChainExpr,
   pub expr: Expr<'a>,
   pub question_dot_token: &'a swc_common::Span,
@@ -11821,8 +12182,12 @@ fn get_view_for_opt_chain_expr<'a>(inner: &'a swc_ast::OptChainExpr, parent: Nod
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Param<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Param,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub pat: Pat<'a>,
@@ -11890,8 +12255,12 @@ fn get_view_for_param<'a>(inner: &'a swc_ast::Param, parent: Node<'a>, bump: &'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ParenExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ParenExpr,
   pub expr: Expr<'a>,
 }
@@ -11953,8 +12322,12 @@ fn get_view_for_paren_expr<'a>(inner: &'a swc_ast::ParenExpr, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct PrivateMethod<'a> {
+  #[serde(skip)]
   pub parent: &'a Class<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::PrivateMethod,
   pub key: &'a PrivateName<'a>,
   pub function: &'a Function<'a>,
@@ -12032,8 +12405,12 @@ fn get_view_for_private_method<'a>(inner: &'a swc_ast::PrivateMethod, parent: No
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct PrivateName<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::PrivateName,
   pub id: &'a Ident<'a>,
 }
@@ -12095,8 +12472,12 @@ fn get_view_for_private_name<'a>(inner: &'a swc_ast::PrivateName, parent: Node<'
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct PrivateProp<'a> {
+  #[serde(skip)]
   pub parent: &'a Class<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::PrivateProp,
   pub key: &'a PrivateName<'a>,
   pub value: Option<Expr<'a>>,
@@ -12198,8 +12579,12 @@ fn get_view_for_private_prop<'a>(inner: &'a swc_ast::PrivateProp, parent: Node<'
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Regex<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Regex,
   pub exp: &'a swc_atoms::JsWord,
   pub flags: &'a swc_atoms::JsWord,
@@ -12260,8 +12645,12 @@ fn get_view_for_regex<'a>(inner: &'a swc_ast::Regex, parent: Node<'a>, bump: &'a
 }
 
 /// EsTree `RestElement`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct RestPat<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::RestPat,
   pub arg: Pat<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -12334,8 +12723,12 @@ fn get_view_for_rest_pat<'a>(inner: &'a swc_ast::RestPat, parent: Node<'a>, bump
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ReturnStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ReturnStmt,
   pub arg: Option<Expr<'a>>,
 }
@@ -12402,10 +12795,16 @@ fn get_view_for_return_stmt<'a>(inner: &'a swc_ast::ReturnStmt, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Script<'a> {
+  #[serde(skip)]
   pub source_file: Option<&'a swc_common::SourceFile>,
+  #[serde(skip)]
   pub tokens: Option<&'a TokenContainer<'a>>,
+  #[serde(skip)]
   pub comments: Option<&'a CommentContainer<'a>>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Script,
   pub body: Vec<Stmt<'a>>,
   pub shebang: &'a Option<swc_atoms::JsWord>,
@@ -12480,8 +12879,12 @@ fn get_view_for_script<'a>(source_file_info: &'a ScriptInfo<'a>, bump: &'a Bump)
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct SeqExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::SeqExpr,
   pub exprs: Vec<Expr<'a>>,
 }
@@ -12545,8 +12948,12 @@ fn get_view_for_seq_expr<'a>(inner: &'a swc_ast::SeqExpr, parent: Node<'a>, bump
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct SetterProp<'a> {
+  #[serde(skip)]
   pub parent: &'a ObjectLit<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::SetterProp,
   pub key: PropName<'a>,
   pub param: Pat<'a>,
@@ -12621,8 +13028,12 @@ fn get_view_for_setter_prop<'a>(inner: &'a swc_ast::SetterProp, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct SpreadElement<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::SpreadElement,
   pub expr: Expr<'a>,
   pub dot3_token: &'a swc_common::Span,
@@ -12686,8 +13097,12 @@ fn get_view_for_spread_element<'a>(inner: &'a swc_ast::SpreadElement, parent: No
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Str<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Str,
   pub value: &'a swc_atoms::JsWord,
   /// This includes line escape.
@@ -12750,8 +13165,12 @@ fn get_view_for_str<'a>(inner: &'a swc_ast::Str, parent: Node<'a>, bump: &'a Bum
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Super<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Super,
 }
 
@@ -12807,8 +13226,12 @@ fn get_view_for_super<'a>(inner: &'a swc_ast::Super, parent: Node<'a>, bump: &'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct SwitchCase<'a> {
+  #[serde(skip)]
   pub parent: &'a SwitchStmt<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::SwitchCase,
   /// None for `default:`
   pub test: Option<Expr<'a>>,
@@ -12882,8 +13305,12 @@ fn get_view_for_switch_case<'a>(inner: &'a swc_ast::SwitchCase, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct SwitchStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::SwitchStmt,
   pub discriminant: Expr<'a>,
   pub cases: Vec<&'a SwitchCase<'a>>,
@@ -12951,8 +13378,12 @@ fn get_view_for_switch_stmt<'a>(inner: &'a swc_ast::SwitchStmt, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TaggedTpl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TaggedTpl,
   pub tag: Expr<'a>,
   pub exprs: Vec<Expr<'a>>,
@@ -13035,8 +13466,12 @@ fn get_view_for_tagged_tpl<'a>(inner: &'a swc_ast::TaggedTpl, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ThisExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ThisExpr,
 }
 
@@ -13092,8 +13527,12 @@ fn get_view_for_this_expr<'a>(inner: &'a swc_ast::ThisExpr, parent: Node<'a>, bu
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct ThrowStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::ThrowStmt,
   pub arg: Expr<'a>,
 }
@@ -13155,8 +13594,12 @@ fn get_view_for_throw_stmt<'a>(inner: &'a swc_ast::ThrowStmt, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct Tpl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::Tpl,
   pub exprs: Vec<Expr<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
@@ -13226,8 +13669,12 @@ fn get_view_for_tpl<'a>(inner: &'a swc_ast::Tpl, parent: Node<'a>, bump: &'a Bum
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TplElement<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TplElement,
   pub cooked: Option<&'a Str<'a>>,
   pub raw: &'a Str<'a>,
@@ -13300,8 +13747,12 @@ fn get_view_for_tpl_element<'a>(inner: &'a swc_ast::TplElement, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TryStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TryStmt,
   pub block: &'a BlockStmt<'a>,
   pub handler: Option<&'a CatchClause<'a>>,
@@ -13381,8 +13832,12 @@ fn get_view_for_try_stmt<'a>(inner: &'a swc_ast::TryStmt, parent: Node<'a>, bump
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsArrayType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsArrayType,
   pub elem_type: TsType<'a>,
 }
@@ -13444,8 +13899,12 @@ fn get_view_for_ts_array_type<'a>(inner: &'a swc_ast::TsArrayType, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsAsExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsAsExpr,
   pub expr: Expr<'a>,
   pub type_ann: TsType<'a>,
@@ -13511,8 +13970,12 @@ fn get_view_for_ts_as_expr<'a>(inner: &'a swc_ast::TsAsExpr, parent: Node<'a>, b
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsCallSignatureDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsCallSignatureDecl,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -13594,8 +14057,12 @@ fn get_view_for_ts_call_signature_decl<'a>(inner: &'a swc_ast::TsCallSignatureDe
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsConditionalType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsConditionalType,
   pub check_type: TsType<'a>,
   pub extends_type: TsType<'a>,
@@ -13669,8 +14136,12 @@ fn get_view_for_ts_conditional_type<'a>(inner: &'a swc_ast::TsConditionalType, p
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsConstAssertion<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsConstAssertion,
   pub expr: Expr<'a>,
 }
@@ -13732,8 +14203,12 @@ fn get_view_for_ts_const_assertion<'a>(inner: &'a swc_ast::TsConstAssertion, par
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsConstructSignatureDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsConstructSignatureDecl,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -13815,8 +14290,12 @@ fn get_view_for_ts_construct_signature_decl<'a>(inner: &'a swc_ast::TsConstructS
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsConstructorType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsConstructorType,
   pub params: Vec<TsFnParam<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -13895,8 +14374,12 @@ fn get_view_for_ts_constructor_type<'a>(inner: &'a swc_ast::TsConstructorType, p
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsEnumDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsEnumDecl,
   pub id: &'a Ident<'a>,
   pub members: Vec<&'a TsEnumMember<'a>>,
@@ -13968,8 +14451,12 @@ fn get_view_for_ts_enum_decl<'a>(inner: &'a swc_ast::TsEnumDecl, parent: Node<'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsEnumMember<'a> {
+  #[serde(skip)]
   pub parent: &'a TsEnumDecl<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsEnumMember,
   pub id: TsEnumMemberId<'a>,
   pub init: Option<Expr<'a>>,
@@ -14043,8 +14530,12 @@ fn get_view_for_ts_enum_member<'a>(inner: &'a swc_ast::TsEnumMember, parent: Nod
 /// TypeScript's own parser uses ExportAssignment for both `export default` and
 /// `export =`. But for @babel/parser, `export default` is an ExportDefaultDecl,
 /// so a TsExportAssignment is always `export =`.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsExportAssignment<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsExportAssignment,
   pub expr: Expr<'a>,
 }
@@ -14106,8 +14597,12 @@ fn get_view_for_ts_export_assignment<'a>(inner: &'a swc_ast::TsExportAssignment,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsExprWithTypeArgs<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsExprWithTypeArgs,
   pub expr: TsEntityName<'a>,
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -14178,8 +14673,12 @@ fn get_view_for_ts_expr_with_type_args<'a>(inner: &'a swc_ast::TsExprWithTypeArg
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsExternalModuleRef<'a> {
+  #[serde(skip)]
   pub parent: &'a TsImportEqualsDecl<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsExternalModuleRef,
   pub expr: &'a Str<'a>,
 }
@@ -14241,8 +14740,12 @@ fn get_view_for_ts_external_module_ref<'a>(inner: &'a swc_ast::TsExternalModuleR
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsFnType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsFnType,
   pub params: Vec<TsFnParam<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -14319,8 +14822,12 @@ fn get_view_for_ts_fn_type<'a>(inner: &'a swc_ast::TsFnType, parent: Node<'a>, b
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsImportEqualsDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsImportEqualsDecl,
   pub id: &'a Ident<'a>,
   pub module_ref: TsModuleRef<'a>,
@@ -14390,8 +14897,12 @@ fn get_view_for_ts_import_equals_decl<'a>(inner: &'a swc_ast::TsImportEqualsDecl
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsImportType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsImportType,
   pub arg: &'a Str<'a>,
   pub qualifier: Option<TsEntityName<'a>>,
@@ -14471,8 +14982,12 @@ fn get_view_for_ts_import_type<'a>(inner: &'a swc_ast::TsImportType, parent: Nod
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsIndexSignature<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsIndexSignature,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -14547,8 +15062,12 @@ fn get_view_for_ts_index_signature<'a>(inner: &'a swc_ast::TsIndexSignature, par
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsIndexedAccessType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsIndexedAccessType,
   pub obj_type: TsType<'a>,
   pub index_type: TsType<'a>,
@@ -14616,8 +15135,12 @@ fn get_view_for_ts_indexed_access_type<'a>(inner: &'a swc_ast::TsIndexedAccessTy
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsInferType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsInferType,
   pub type_param: &'a TsTypeParam<'a>,
 }
@@ -14679,8 +15202,12 @@ fn get_view_for_ts_infer_type<'a>(inner: &'a swc_ast::TsInferType, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsInterfaceBody<'a> {
+  #[serde(skip)]
   pub parent: &'a TsInterfaceDecl<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsInterfaceBody,
   pub body: Vec<TsTypeElement<'a>>,
 }
@@ -14744,8 +15271,12 @@ fn get_view_for_ts_interface_body<'a>(inner: &'a swc_ast::TsInterfaceBody, paren
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsInterfaceDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsInterfaceDecl,
   pub id: &'a Ident<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -14828,8 +15359,12 @@ fn get_view_for_ts_interface_decl<'a>(inner: &'a swc_ast::TsInterfaceDecl, paren
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsIntersectionType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsIntersectionType,
   pub types: Vec<TsType<'a>>,
 }
@@ -14893,8 +15428,12 @@ fn get_view_for_ts_intersection_type<'a>(inner: &'a swc_ast::TsIntersectionType,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsKeywordType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsKeywordType,
   pub kind: TsKeywordTypeKind,
 }
@@ -14952,8 +15491,12 @@ fn get_view_for_ts_keyword_type<'a>(inner: &'a swc_ast::TsKeywordType, parent: N
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsLitType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsLitType,
   pub lit: TsLit<'a>,
 }
@@ -15015,8 +15558,12 @@ fn get_view_for_ts_lit_type<'a>(inner: &'a swc_ast::TsLitType, parent: Node<'a>,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsMappedType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsMappedType,
   pub type_param: &'a TsTypeParam<'a>,
   pub name_type: Option<TsType<'a>>,
@@ -15100,8 +15647,12 @@ fn get_view_for_ts_mapped_type<'a>(inner: &'a swc_ast::TsMappedType, parent: Nod
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsMethodSignature<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsMethodSignature,
   pub key: Expr<'a>,
   pub params: Vec<TsFnParam<'a>>,
@@ -15193,8 +15744,12 @@ fn get_view_for_ts_method_signature<'a>(inner: &'a swc_ast::TsMethodSignature, p
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsModuleBlock<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsModuleBlock,
   pub body: Vec<ModuleItem<'a>>,
 }
@@ -15258,8 +15813,12 @@ fn get_view_for_ts_module_block<'a>(inner: &'a swc_ast::TsModuleBlock, parent: N
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsModuleDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsModuleDecl,
   pub id: TsModuleName<'a>,
   pub body: Option<TsNamespaceBody<'a>>,
@@ -15335,8 +15894,12 @@ fn get_view_for_ts_module_decl<'a>(inner: &'a swc_ast::TsModuleDecl, parent: Nod
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsNamespaceDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsNamespaceDecl,
   pub id: &'a Ident<'a>,
   pub body: TsNamespaceBody<'a>,
@@ -15407,8 +15970,12 @@ fn get_view_for_ts_namespace_decl<'a>(inner: &'a swc_ast::TsNamespaceDecl, paren
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsNamespaceExportDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsNamespaceExportDecl,
   pub id: &'a Ident<'a>,
 }
@@ -15470,8 +16037,12 @@ fn get_view_for_ts_namespace_export_decl<'a>(inner: &'a swc_ast::TsNamespaceExpo
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsNonNullExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsNonNullExpr,
   pub expr: Expr<'a>,
 }
@@ -15533,8 +16104,12 @@ fn get_view_for_ts_non_null_expr<'a>(inner: &'a swc_ast::TsNonNullExpr, parent: 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsOptionalType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsOptionalType,
   pub type_ann: TsType<'a>,
 }
@@ -15596,8 +16171,12 @@ fn get_view_for_ts_optional_type<'a>(inner: &'a swc_ast::TsOptionalType, parent:
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsParamProp<'a> {
+  #[serde(skip)]
   pub parent: &'a Constructor<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsParamProp,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub param: TsParamPropParam<'a>,
@@ -15670,8 +16249,12 @@ fn get_view_for_ts_param_prop<'a>(inner: &'a swc_ast::TsParamProp, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsParenthesizedType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsParenthesizedType,
   pub type_ann: TsType<'a>,
 }
@@ -15733,8 +16316,12 @@ fn get_view_for_ts_parenthesized_type<'a>(inner: &'a swc_ast::TsParenthesizedTyp
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsPropertySignature<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsPropertySignature,
   pub key: Expr<'a>,
   pub init: Option<Expr<'a>>,
@@ -15835,8 +16422,12 @@ fn get_view_for_ts_property_signature<'a>(inner: &'a swc_ast::TsPropertySignatur
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsQualifiedName<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsQualifiedName,
   pub left: TsEntityName<'a>,
   pub right: &'a Ident<'a>,
@@ -15902,8 +16493,12 @@ fn get_view_for_ts_qualified_name<'a>(inner: &'a swc_ast::TsQualifiedName, paren
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsRestType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsRestType,
   pub type_ann: TsType<'a>,
 }
@@ -15965,8 +16560,12 @@ fn get_view_for_ts_rest_type<'a>(inner: &'a swc_ast::TsRestType, parent: Node<'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsThisType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsThisType,
 }
 
@@ -16022,8 +16621,12 @@ fn get_view_for_ts_this_type<'a>(inner: &'a swc_ast::TsThisType, parent: Node<'a
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTplLitType<'a> {
+  #[serde(skip)]
   pub parent: &'a TsLitType<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTplLitType,
   pub types: Vec<TsType<'a>>,
   pub quasis: Vec<&'a TplElement<'a>>,
@@ -16093,8 +16696,12 @@ fn get_view_for_ts_tpl_lit_type<'a>(inner: &'a swc_ast::TsTplLitType, parent: No
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTupleElement<'a> {
+  #[serde(skip)]
   pub parent: &'a TsTupleType<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTupleElement,
   /// `Ident` or `RestPat { arg: Ident }`
   pub label: Option<Pat<'a>>,
@@ -16166,8 +16773,12 @@ fn get_view_for_ts_tuple_element<'a>(inner: &'a swc_ast::TsTupleElement, parent:
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTupleType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTupleType,
   pub elem_types: Vec<&'a TsTupleElement<'a>>,
 }
@@ -16231,8 +16842,12 @@ fn get_view_for_ts_tuple_type<'a>(inner: &'a swc_ast::TsTupleType, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeAliasDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAliasDecl,
   pub id: &'a Ident<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
@@ -16309,8 +16924,12 @@ fn get_view_for_ts_type_alias_decl<'a>(inner: &'a swc_ast::TsTypeAliasDecl, pare
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeAnn<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAnn,
   pub type_ann: TsType<'a>,
 }
@@ -16372,8 +16991,12 @@ fn get_view_for_ts_type_ann<'a>(inner: &'a swc_ast::TsTypeAnn, parent: Node<'a>,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeAssertion<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeAssertion,
   pub expr: Expr<'a>,
   pub type_ann: TsType<'a>,
@@ -16439,8 +17062,12 @@ fn get_view_for_ts_type_assertion<'a>(inner: &'a swc_ast::TsTypeAssertion, paren
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeLit<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeLit,
   pub members: Vec<TsTypeElement<'a>>,
 }
@@ -16504,8 +17131,12 @@ fn get_view_for_ts_type_lit<'a>(inner: &'a swc_ast::TsTypeLit, parent: Node<'a>,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeOperator<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeOperator,
   pub type_ann: TsType<'a>,
   pub op: TsTypeOperatorOp,
@@ -16569,8 +17200,12 @@ fn get_view_for_ts_type_operator<'a>(inner: &'a swc_ast::TsTypeOperator, parent:
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeParam<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParam,
   pub name: &'a Ident<'a>,
   pub constraint: Option<TsType<'a>>,
@@ -16650,8 +17285,12 @@ fn get_view_for_ts_type_param<'a>(inner: &'a swc_ast::TsTypeParam, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeParamDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParamDecl,
   pub params: Vec<&'a TsTypeParam<'a>>,
 }
@@ -16715,8 +17354,12 @@ fn get_view_for_ts_type_param_decl<'a>(inner: &'a swc_ast::TsTypeParamDecl, pare
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeParamInstantiation<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeParamInstantiation,
   pub params: Vec<TsType<'a>>,
 }
@@ -16780,8 +17423,12 @@ fn get_view_for_ts_type_param_instantiation<'a>(inner: &'a swc_ast::TsTypeParamI
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypePredicate<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypePredicate,
   pub param_name: TsThisTypeOrIdent<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
@@ -16855,8 +17502,12 @@ fn get_view_for_ts_type_predicate<'a>(inner: &'a swc_ast::TsTypePredicate, paren
 }
 
 /// `typeof` operator
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeQuery<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeQuery,
   pub expr_name: TsTypeQueryExpr<'a>,
 }
@@ -16918,8 +17569,12 @@ fn get_view_for_ts_type_query<'a>(inner: &'a swc_ast::TsTypeQuery, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsTypeRef<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsTypeRef,
   pub type_name: TsEntityName<'a>,
   pub type_params: Option<&'a TsTypeParamInstantiation<'a>>,
@@ -16990,8 +17645,12 @@ fn get_view_for_ts_type_ref<'a>(inner: &'a swc_ast::TsTypeRef, parent: Node<'a>,
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct TsUnionType<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::TsUnionType,
   pub types: Vec<TsType<'a>>,
 }
@@ -17055,8 +17714,12 @@ fn get_view_for_ts_union_type<'a>(inner: &'a swc_ast::TsUnionType, parent: Node<
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct UnaryExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::UnaryExpr,
   pub arg: Expr<'a>,
   pub op: UnaryOp,
@@ -17120,8 +17783,12 @@ fn get_view_for_unary_expr<'a>(inner: &'a swc_ast::UnaryExpr, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct UpdateExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::UpdateExpr,
   pub arg: Expr<'a>,
   pub op: UpdateOp,
@@ -17187,8 +17854,12 @@ fn get_view_for_update_expr<'a>(inner: &'a swc_ast::UpdateExpr, parent: Node<'a>
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct VarDecl<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::VarDecl,
   pub decls: Vec<&'a VarDeclarator<'a>>,
   pub kind: VarDeclKind,
@@ -17256,8 +17927,12 @@ fn get_view_for_var_decl<'a>(inner: &'a swc_ast::VarDecl, parent: Node<'a>, bump
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct VarDeclarator<'a> {
+  #[serde(skip)]
   pub parent: &'a VarDecl<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::VarDeclarator,
   pub name: Pat<'a>,
   /// Initialization expression.
@@ -17332,8 +18007,12 @@ fn get_view_for_var_declarator<'a>(inner: &'a swc_ast::VarDeclarator, parent: No
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct WhileStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::WhileStmt,
   pub test: Expr<'a>,
   pub body: Stmt<'a>,
@@ -17399,8 +18078,12 @@ fn get_view_for_while_stmt<'a>(inner: &'a swc_ast::WhileStmt, parent: Node<'a>, 
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct WithStmt<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::WithStmt,
   pub obj: Expr<'a>,
   pub body: Stmt<'a>,
@@ -17466,8 +18149,12 @@ fn get_view_for_with_stmt<'a>(inner: &'a swc_ast::WithStmt, parent: Node<'a>, bu
   node
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "nodeKind")]
 pub struct YieldExpr<'a> {
+  #[serde(skip)]
   pub parent: Node<'a>,
+  #[serde(skip)]
   pub inner: &'a swc_ast::YieldExpr,
   pub arg: Option<Expr<'a>>,
   pub delegate: bool,

--- a/rs-lib/src/generated.rs
+++ b/rs-lib/src/generated.rs
@@ -6316,13 +6316,8 @@ pub struct ArrayPat<'a> {
   pub inner: &'a swc_ast::ArrayPat,
   pub elems: Vec<Option<Pat<'a>>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-}
-
-impl<'a> ArrayPat<'a> {
   /// Only in an ambient context
-  pub fn optional(&self) -> bool {
-    self.inner.optional
-  }
+  pub optional: bool,
 }
 
 impl<'a> Spanned for ArrayPat<'a> {
@@ -6384,6 +6379,7 @@ fn get_view_for_array_pat<'a>(inner: &'a swc_ast::ArrayPat, parent: Node<'a>, bu
     parent,
     elems: Vec::with_capacity(inner.elems.len()),
     type_ann: None,
+    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.elems.extend(inner.elems.iter().map(|value| match value {
@@ -6404,16 +6400,8 @@ pub struct ArrowExpr<'a> {
   pub body: BlockStmtOrExpr<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub return_type: Option<&'a TsTypeAnn<'a>>,
-}
-
-impl<'a> ArrowExpr<'a> {
-  pub fn is_async(&self) -> bool {
-    self.inner.is_async
-  }
-
-  pub fn is_generator(&self) -> bool {
-    self.inner.is_generator
-  }
+  pub is_async: bool,
+  pub is_generator: bool,
 }
 
 impl<'a> Spanned for ArrowExpr<'a> {
@@ -6479,6 +6467,8 @@ fn get_view_for_arrow_expr<'a>(inner: &'a swc_ast::ArrowExpr, parent: Node<'a>, 
     body: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
     return_type: None,
+    is_async: inner.is_async,
+    is_generator: inner.is_generator,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_pat(value, parent.clone(), bump)));
@@ -6499,12 +6489,7 @@ pub struct AssignExpr<'a> {
   pub inner: &'a swc_ast::AssignExpr,
   pub left: PatOrExpr<'a>,
   pub right: Expr<'a>,
-}
-
-impl<'a> AssignExpr<'a> {
-  pub fn op(&self) -> AssignOp {
-    self.inner.op
-  }
+  pub op: AssignOp,
 }
 
 impl<'a> Spanned for AssignExpr<'a> {
@@ -6560,6 +6545,7 @@ fn get_view_for_assign_expr<'a>(inner: &'a swc_ast::AssignExpr, parent: Node<'a>
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
+    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.left = get_view_for_pat_or_expr(&inner.left, parent.clone(), bump);
@@ -6849,12 +6835,7 @@ fn get_view_for_await_expr<'a>(inner: &'a swc_ast::AwaitExpr, parent: Node<'a>, 
 pub struct BigInt<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::BigInt,
-}
-
-impl<'a> BigInt<'a> {
-  pub fn value(&self) -> &num_bigint::BigInt {
-    &self.inner.value
-  }
+  pub value: &'a num_bigint::BigInt,
 }
 
 impl<'a> Spanned for BigInt<'a> {
@@ -6905,6 +6886,7 @@ fn get_view_for_big_int<'a>(inner: &'a swc_ast::BigInt, parent: Node<'a>, bump: 
   let node = bump.alloc(BigInt {
     inner,
     parent,
+    value: &inner.value,
   });
   node
 }
@@ -6914,12 +6896,7 @@ pub struct BinExpr<'a> {
   pub inner: &'a swc_ast::BinExpr,
   pub left: Expr<'a>,
   pub right: Expr<'a>,
-}
-
-impl<'a> BinExpr<'a> {
-  pub fn op(&self) -> BinaryOp {
-    self.inner.op
-  }
+  pub op: BinaryOp,
 }
 
 impl<'a> Spanned for BinExpr<'a> {
@@ -6975,6 +6952,7 @@ fn get_view_for_bin_expr<'a>(inner: &'a swc_ast::BinExpr, parent: Node<'a>, bump
     parent,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
+    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.left = get_view_for_expr(&inner.left, parent.clone(), bump);
@@ -7124,12 +7102,7 @@ fn get_view_for_block_stmt<'a>(inner: &'a swc_ast::BlockStmt, parent: Node<'a>, 
 pub struct Bool<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::Bool,
-}
-
-impl<'a> Bool<'a> {
-  pub fn value(&self) -> bool {
-    self.inner.value
-  }
+  pub value: bool,
 }
 
 impl<'a> Spanned for Bool<'a> {
@@ -7180,6 +7153,7 @@ fn get_view_for_bool<'a>(inner: &'a swc_ast::Bool, parent: Node<'a>, bump: &'a B
   let node = bump.alloc(Bool {
     inner,
     parent,
+    value: inner.value,
   });
   node
 }
@@ -7416,12 +7390,7 @@ pub struct Class<'a> {
   pub super_type_params: Option<&'a TsTypeParamInstantiation<'a>>,
   /// Typescript extension.
   pub implements: Vec<&'a TsExprWithTypeArgs<'a>>,
-}
-
-impl<'a> Class<'a> {
-  pub fn is_abstract(&self) -> bool {
-    self.inner.is_abstract
-  }
+  pub is_abstract: bool,
 }
 
 impl<'a> Spanned for Class<'a> {
@@ -7497,6 +7466,7 @@ fn get_view_for_class<'a>(inner: &'a swc_ast::Class, parent: Node<'a>, bump: &'a
     type_params: None,
     super_type_params: None,
     implements: Vec::with_capacity(inner.implements.len()),
+    is_abstract: inner.is_abstract,
   });
   let parent: Node<'a> = (&*node).into();
   node.decorators.extend(inner.decorators.iter().map(|value| get_view_for_decorator(value, parent.clone(), bump)));
@@ -7522,12 +7492,7 @@ pub struct ClassDecl<'a> {
   pub inner: &'a swc_ast::ClassDecl,
   pub ident: &'a Ident<'a>,
   pub class: &'a Class<'a>,
-}
-
-impl<'a> ClassDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
+  pub declare: bool,
 }
 
 impl<'a> Spanned for ClassDecl<'a> {
@@ -7583,6 +7548,7 @@ fn get_view_for_class_decl<'a>(inner: &'a swc_ast::ClassDecl, parent: Node<'a>, 
     parent,
     ident: unsafe { MaybeUninit::uninit().assume_init() },
     class: unsafe { MaybeUninit::uninit().assume_init() },
+    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.ident = get_view_for_ident(&inner.ident, parent.clone(), bump);
@@ -7668,30 +7634,13 @@ pub struct ClassMethod<'a> {
   pub inner: &'a swc_ast::ClassMethod,
   pub key: PropName<'a>,
   pub function: &'a Function<'a>,
-}
-
-impl<'a> ClassMethod<'a> {
-  pub fn kind(&self) -> MethodKind {
-    self.inner.kind
-  }
-
-  pub fn is_static(&self) -> bool {
-    self.inner.is_static
-  }
-
+  pub kind: MethodKind,
+  pub is_static: bool,
   /// Typescript extension.
-  pub fn accessibility(&self) -> Option<Accessibility> {
-    self.inner.accessibility
-  }
-
+  pub accessibility: Option<Accessibility>,
   /// Typescript extension.
-  pub fn is_abstract(&self) -> bool {
-    self.inner.is_abstract
-  }
-
-  pub fn is_optional(&self) -> bool {
-    self.inner.is_optional
-  }
+  pub is_abstract: bool,
+  pub is_optional: bool,
 }
 
 impl<'a> Spanned for ClassMethod<'a> {
@@ -7747,6 +7696,11 @@ fn get_view_for_class_method<'a>(inner: &'a swc_ast::ClassMethod, parent: Node<'
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
+    kind: inner.kind,
+    is_static: inner.is_static,
+    accessibility: inner.accessibility,
+    is_abstract: inner.is_abstract,
+    is_optional: inner.is_optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_prop_name(&inner.key, parent.clone(), bump);
@@ -7761,42 +7715,16 @@ pub struct ClassProp<'a> {
   pub value: Option<Expr<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub decorators: Vec<&'a Decorator<'a>>,
-}
-
-impl<'a> ClassProp<'a> {
-  pub fn is_static(&self) -> bool {
-    self.inner.is_static
-  }
-
-  pub fn computed(&self) -> bool {
-    self.inner.computed
-  }
-
+  pub is_static: bool,
+  pub computed: bool,
   /// Typescript extension.
-  pub fn accessibility(&self) -> Option<Accessibility> {
-    self.inner.accessibility
-  }
-
+  pub accessibility: Option<Accessibility>,
   /// Typescript extension.
-  pub fn is_abstract(&self) -> bool {
-    self.inner.is_abstract
-  }
-
-  pub fn is_optional(&self) -> bool {
-    self.inner.is_optional
-  }
-
-  pub fn readonly(&self) -> bool {
-    self.inner.readonly
-  }
-
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
-
-  pub fn definite(&self) -> bool {
-    self.inner.definite
-  }
+  pub is_abstract: bool,
+  pub is_optional: bool,
+  pub readonly: bool,
+  pub declare: bool,
+  pub definite: bool,
 }
 
 impl<'a> Spanned for ClassProp<'a> {
@@ -7862,6 +7790,14 @@ fn get_view_for_class_prop<'a>(inner: &'a swc_ast::ClassProp, parent: Node<'a>, 
     value: None,
     type_ann: None,
     decorators: Vec::with_capacity(inner.decorators.len()),
+    is_static: inner.is_static,
+    computed: inner.computed,
+    accessibility: inner.accessibility,
+    is_abstract: inner.is_abstract,
+    is_optional: inner.is_optional,
+    readonly: inner.readonly,
+    declare: inner.declare,
+    definite: inner.definite,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_expr(&inner.key, parent.clone(), bump);
@@ -8017,16 +7953,8 @@ pub struct Constructor<'a> {
   pub key: PropName<'a>,
   pub params: Vec<ParamOrTsParamProp<'a>>,
   pub body: Option<&'a BlockStmt<'a>>,
-}
-
-impl<'a> Constructor<'a> {
-  pub fn accessibility(&self) -> Option<Accessibility> {
-    self.inner.accessibility
-  }
-
-  pub fn is_optional(&self) -> bool {
-    self.inner.is_optional
-  }
+  pub accessibility: Option<Accessibility>,
+  pub is_optional: bool,
 }
 
 impl<'a> Spanned for Constructor<'a> {
@@ -8088,6 +8016,8 @@ fn get_view_for_constructor<'a>(inner: &'a swc_ast::Constructor, parent: Node<'a
     key: unsafe { MaybeUninit::uninit().assume_init() },
     params: Vec::with_capacity(inner.params.len()),
     body: None,
+    accessibility: inner.accessibility,
+    is_optional: inner.is_optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_prop_name(&inner.key, parent.clone(), bump);
@@ -8878,12 +8808,7 @@ pub struct ExprOrSpread<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::ExprOrSpread,
   pub expr: Expr<'a>,
-}
-
-impl<'a> ExprOrSpread<'a> {
-  pub fn spread(&self) -> &Option<swc_common::Span> {
-    &self.inner.spread
-  }
+  pub spread: &'a Option<swc_common::Span>,
 }
 
 impl<'a> Spanned for ExprOrSpread<'a> {
@@ -8937,6 +8862,7 @@ fn get_view_for_expr_or_spread<'a>(inner: &'a swc_ast::ExprOrSpread, parent: Nod
     inner,
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
+    spread: &inner.spread,
   });
   let parent: Node<'a> = (&*node).into();
   node.expr = get_view_for_expr(&inner.expr, parent, bump);
@@ -9011,12 +8937,7 @@ pub struct FnDecl<'a> {
   pub inner: &'a swc_ast::FnDecl,
   pub ident: &'a Ident<'a>,
   pub function: &'a Function<'a>,
-}
-
-impl<'a> FnDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
+  pub declare: bool,
 }
 
 impl<'a> Spanned for FnDecl<'a> {
@@ -9072,6 +8993,7 @@ fn get_view_for_fn_decl<'a>(inner: &'a swc_ast::FnDecl, parent: Node<'a>, bump: 
     parent,
     ident: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
+    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.ident = get_view_for_ident(&inner.ident, parent.clone(), bump);
@@ -9229,17 +9151,12 @@ pub struct ForOfStmt<'a> {
   pub left: VarDeclOrPat<'a>,
   pub right: Expr<'a>,
   pub body: Stmt<'a>,
-}
-
-impl<'a> ForOfStmt<'a> {
   /// Span of the await token.
   ///
   /// es2018
   ///
   /// for-await-of statements, e.g., `for await (const x of xs) {`
-  pub fn await_token(&self) -> &Option<swc_common::Span> {
-    &self.inner.await_token
-  }
+  pub await_token: &'a Option<swc_common::Span>,
 }
 
 impl<'a> Spanned for ForOfStmt<'a> {
@@ -9297,6 +9214,7 @@ fn get_view_for_for_of_stmt<'a>(inner: &'a swc_ast::ForOfStmt, parent: Node<'a>,
     left: unsafe { MaybeUninit::uninit().assume_init() },
     right: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
+    await_token: &inner.await_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.left = get_view_for_var_decl_or_pat(&inner.left, parent.clone(), bump);
@@ -9404,18 +9322,10 @@ pub struct Function<'a> {
   pub body: Option<&'a BlockStmt<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub return_type: Option<&'a TsTypeAnn<'a>>,
-}
-
-impl<'a> Function<'a> {
   /// if it's a generator.
-  pub fn is_generator(&self) -> bool {
-    self.inner.is_generator
-  }
-
+  pub is_generator: bool,
   /// if it's an async function.
-  pub fn is_async(&self) -> bool {
-    self.inner.is_async
-  }
+  pub is_async: bool,
 }
 
 impl<'a> Spanned for Function<'a> {
@@ -9487,6 +9397,8 @@ fn get_view_for_function<'a>(inner: &'a swc_ast::Function, parent: Node<'a>, bum
     body: None,
     type_params: None,
     return_type: None,
+    is_generator: inner.is_generator,
+    is_async: inner.is_async,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_param(value, parent.clone(), bump)));
@@ -9591,17 +9503,9 @@ fn get_view_for_getter_prop<'a>(inner: &'a swc_ast::GetterProp, parent: Node<'a>
 pub struct Ident<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::Ident,
-}
-
-impl<'a> Ident<'a> {
-  pub fn sym(&self) -> &swc_atoms::JsWord {
-    &self.inner.sym
-  }
-
+  pub sym: &'a swc_atoms::JsWord,
   /// TypeScript only. Used in case of an optional parameter.
-  pub fn optional(&self) -> bool {
-    self.inner.optional
-  }
+  pub optional: bool,
 }
 
 impl<'a> Spanned for Ident<'a> {
@@ -9652,6 +9556,8 @@ fn get_view_for_ident<'a>(inner: &'a swc_ast::Ident, parent: Node<'a>, bump: &'a
   let node = bump.alloc(Ident {
     inner,
     parent,
+    sym: &inner.sym,
+    optional: inner.optional,
   });
   node
 }
@@ -9738,12 +9644,7 @@ pub struct ImportDecl<'a> {
   pub specifiers: Vec<ImportSpecifier<'a>>,
   pub src: &'a Str<'a>,
   pub asserts: Option<&'a ObjectLit<'a>>,
-}
-
-impl<'a> ImportDecl<'a> {
-  pub fn type_only(&self) -> bool {
-    self.inner.type_only
-  }
+  pub type_only: bool,
 }
 
 impl<'a> Spanned for ImportDecl<'a> {
@@ -9805,6 +9706,7 @@ fn get_view_for_import_decl<'a>(inner: &'a swc_ast::ImportDecl, parent: Node<'a>
     specifiers: Vec::with_capacity(inner.specifiers.len()),
     src: unsafe { MaybeUninit::uninit().assume_init() },
     asserts: None,
+    type_only: inner.type_only,
   });
   let parent: Node<'a> = (&*node).into();
   node.specifiers.extend(inner.specifiers.iter().map(|value| get_view_for_import_specifier(value, parent.clone(), bump)));
@@ -10684,12 +10586,7 @@ pub struct JSXOpeningElement<'a> {
   /// Note: This field's name is different from one from babel because it is
   /// misleading
   pub type_args: Option<&'a TsTypeParamInstantiation<'a>>,
-}
-
-impl<'a> JSXOpeningElement<'a> {
-  pub fn self_closing(&self) -> bool {
-    self.inner.self_closing
-  }
+  pub self_closing: bool,
 }
 
 impl<'a> Spanned for JSXOpeningElement<'a> {
@@ -10751,6 +10648,7 @@ fn get_view_for_jsxopening_element<'a>(inner: &'a swc_ast::JSXOpeningElement, pa
     name: unsafe { MaybeUninit::uninit().assume_init() },
     attrs: Vec::with_capacity(inner.attrs.len()),
     type_args: None,
+    self_closing: inner.self_closing,
   });
   let parent: Node<'a> = (&*node).into();
   node.name = get_view_for_jsxelement_name(&inner.name, parent.clone(), bump);
@@ -10885,16 +10783,8 @@ fn get_view_for_jsxspread_child<'a>(inner: &'a swc_ast::JSXSpreadChild, parent: 
 pub struct JSXText<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::JSXText,
-}
-
-impl<'a> JSXText<'a> {
-  pub fn value(&self) -> &swc_atoms::JsWord {
-    &self.inner.value
-  }
-
-  pub fn raw(&self) -> &swc_atoms::JsWord {
-    &self.inner.raw
-  }
+  pub value: &'a swc_atoms::JsWord,
+  pub raw: &'a swc_atoms::JsWord,
 }
 
 impl<'a> Spanned for JSXText<'a> {
@@ -10945,6 +10835,8 @@ fn get_view_for_jsxtext<'a>(inner: &'a swc_ast::JSXText, parent: Node<'a>, bump:
   let node = bump.alloc(JSXText {
     inner,
     parent,
+    value: &inner.value,
+    raw: &inner.raw,
   });
   node
 }
@@ -11156,12 +11048,7 @@ pub struct MemberExpr<'a> {
   pub inner: &'a swc_ast::MemberExpr,
   pub obj: ExprOrSuper<'a>,
   pub prop: Expr<'a>,
-}
-
-impl<'a> MemberExpr<'a> {
-  pub fn computed(&self) -> bool {
-    self.inner.computed
-  }
+  pub computed: bool,
 }
 
 impl<'a> Spanned for MemberExpr<'a> {
@@ -11217,6 +11104,7 @@ fn get_view_for_member_expr<'a>(inner: &'a swc_ast::MemberExpr, parent: Node<'a>
     parent,
     obj: unsafe { MaybeUninit::uninit().assume_init() },
     prop: unsafe { MaybeUninit::uninit().assume_init() },
+    computed: inner.computed,
   });
   let parent: Node<'a> = (&*node).into();
   node.obj = get_view_for_expr_or_super(&inner.obj, parent.clone(), bump);
@@ -11364,12 +11252,7 @@ pub struct Module<'a> {
   pub comments: Option<&'a CommentContainer<'a>>,
   pub inner: &'a swc_ast::Module,
   pub body: Vec<ModuleItem<'a>>,
-}
-
-impl<'a> Module<'a> {
-  pub fn shebang(&self) -> &Option<swc_atoms::JsWord> {
-    &self.inner.shebang
-  }
+  pub shebang: &'a Option<swc_atoms::JsWord>,
 }
 
 impl<'a> Spanned for Module<'a> {
@@ -11434,6 +11317,7 @@ fn get_view_for_module<'a>(source_file_info: &'a ModuleInfo<'a>, bump: &'a Bump)
     tokens,
     comments,
     body: Vec::with_capacity(inner.body.len()),
+    shebang: &inner.shebang,
   });
   let parent: Node<'a> = (&*node).into();
   node.body.extend(inner.body.iter().map(|value| get_view_for_module_item(value, parent.clone(), bump)));
@@ -11448,12 +11332,7 @@ pub struct NamedExport<'a> {
   pub specifiers: Vec<ExportSpecifier<'a>>,
   pub src: Option<&'a Str<'a>>,
   pub asserts: Option<&'a ObjectLit<'a>>,
-}
-
-impl<'a> NamedExport<'a> {
-  pub fn type_only(&self) -> bool {
-    self.inner.type_only
-  }
+  pub type_only: bool,
 }
 
 impl<'a> Spanned for NamedExport<'a> {
@@ -11517,6 +11396,7 @@ fn get_view_for_named_export<'a>(inner: &'a swc_ast::NamedExport, parent: Node<'
     specifiers: Vec::with_capacity(inner.specifiers.len()),
     src: None,
     asserts: None,
+    type_only: inner.type_only,
   });
   let parent: Node<'a> = (&*node).into();
   node.specifiers.extend(inner.specifiers.iter().map(|value| get_view_for_export_specifier(value, parent.clone(), bump)));
@@ -11674,15 +11554,10 @@ fn get_view_for_null<'a>(inner: &'a swc_ast::Null, parent: Node<'a>, bump: &'a B
 pub struct Number<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::Number,
-}
-
-impl<'a> Number<'a> {
   /// **Note**: This should not be `NaN`. Use [crate::Ident] to represent NaN.
   ///
   /// If you store `NaN` in this field, a hash map will behave strangely.
-  pub fn value(&self) -> f64 {
-    self.inner.value
-  }
+  pub value: f64,
 }
 
 impl<'a> Spanned for Number<'a> {
@@ -11733,6 +11608,7 @@ fn get_view_for_number<'a>(inner: &'a swc_ast::Number, parent: Node<'a>, bump: &
   let node = bump.alloc(Number {
     inner,
     parent,
+    value: inner.value,
   });
   node
 }
@@ -11808,13 +11684,8 @@ pub struct ObjectPat<'a> {
   pub inner: &'a swc_ast::ObjectPat,
   pub props: Vec<ObjectPatProp<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-}
-
-impl<'a> ObjectPat<'a> {
   /// Only in an ambient context
-  pub fn optional(&self) -> bool {
-    self.inner.optional
-  }
+  pub optional: bool,
 }
 
 impl<'a> Spanned for ObjectPat<'a> {
@@ -11874,6 +11745,7 @@ fn get_view_for_object_pat<'a>(inner: &'a swc_ast::ObjectPat, parent: Node<'a>, 
     parent,
     props: Vec::with_capacity(inner.props.len()),
     type_ann: None,
+    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.props.extend(inner.props.iter().map(|value| get_view_for_object_pat_prop(value, parent.clone(), bump)));
@@ -11888,12 +11760,7 @@ pub struct OptChainExpr<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::OptChainExpr,
   pub expr: Expr<'a>,
-}
-
-impl<'a> OptChainExpr<'a> {
-  pub fn question_dot_token(&self) -> &swc_common::Span {
-    &self.inner.question_dot_token
-  }
+  pub question_dot_token: &'a swc_common::Span,
 }
 
 impl<'a> Spanned for OptChainExpr<'a> {
@@ -11947,6 +11814,7 @@ fn get_view_for_opt_chain_expr<'a>(inner: &'a swc_ast::OptChainExpr, parent: Nod
     inner,
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
+    question_dot_token: &inner.question_dot_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.expr = get_view_for_expr(&inner.expr, parent, bump);
@@ -12090,30 +11958,13 @@ pub struct PrivateMethod<'a> {
   pub inner: &'a swc_ast::PrivateMethod,
   pub key: &'a PrivateName<'a>,
   pub function: &'a Function<'a>,
-}
-
-impl<'a> PrivateMethod<'a> {
-  pub fn kind(&self) -> MethodKind {
-    self.inner.kind
-  }
-
-  pub fn is_static(&self) -> bool {
-    self.inner.is_static
-  }
-
+  pub kind: MethodKind,
+  pub is_static: bool,
   /// Typescript extension.
-  pub fn accessibility(&self) -> Option<Accessibility> {
-    self.inner.accessibility
-  }
-
+  pub accessibility: Option<Accessibility>,
   /// Typescript extension.
-  pub fn is_abstract(&self) -> bool {
-    self.inner.is_abstract
-  }
-
-  pub fn is_optional(&self) -> bool {
-    self.inner.is_optional
-  }
+  pub is_abstract: bool,
+  pub is_optional: bool,
 }
 
 impl<'a> Spanned for PrivateMethod<'a> {
@@ -12169,6 +12020,11 @@ fn get_view_for_private_method<'a>(inner: &'a swc_ast::PrivateMethod, parent: No
     parent: parent.expect::<Class>(),
     key: unsafe { MaybeUninit::uninit().assume_init() },
     function: unsafe { MaybeUninit::uninit().assume_init() },
+    kind: inner.kind,
+    is_static: inner.is_static,
+    accessibility: inner.accessibility,
+    is_abstract: inner.is_abstract,
+    is_optional: inner.is_optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_private_name(&inner.key, parent.clone(), bump);
@@ -12246,38 +12102,15 @@ pub struct PrivateProp<'a> {
   pub value: Option<Expr<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub decorators: Vec<&'a Decorator<'a>>,
-}
-
-impl<'a> PrivateProp<'a> {
-  pub fn is_static(&self) -> bool {
-    self.inner.is_static
-  }
-
-  pub fn computed(&self) -> bool {
-    self.inner.computed
-  }
-
+  pub is_static: bool,
+  pub computed: bool,
   /// Typescript extension.
-  pub fn accessibility(&self) -> Option<Accessibility> {
-    self.inner.accessibility
-  }
-
+  pub accessibility: Option<Accessibility>,
   /// Typescript extension.
-  pub fn is_abstract(&self) -> bool {
-    self.inner.is_abstract
-  }
-
-  pub fn is_optional(&self) -> bool {
-    self.inner.is_optional
-  }
-
-  pub fn readonly(&self) -> bool {
-    self.inner.readonly
-  }
-
-  pub fn definite(&self) -> bool {
-    self.inner.definite
-  }
+  pub is_abstract: bool,
+  pub is_optional: bool,
+  pub readonly: bool,
+  pub definite: bool,
 }
 
 impl<'a> Spanned for PrivateProp<'a> {
@@ -12343,6 +12176,13 @@ fn get_view_for_private_prop<'a>(inner: &'a swc_ast::PrivateProp, parent: Node<'
     value: None,
     type_ann: None,
     decorators: Vec::with_capacity(inner.decorators.len()),
+    is_static: inner.is_static,
+    computed: inner.computed,
+    accessibility: inner.accessibility,
+    is_abstract: inner.is_abstract,
+    is_optional: inner.is_optional,
+    readonly: inner.readonly,
+    definite: inner.definite,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_private_name(&inner.key, parent.clone(), bump);
@@ -12361,16 +12201,8 @@ fn get_view_for_private_prop<'a>(inner: &'a swc_ast::PrivateProp, parent: Node<'
 pub struct Regex<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::Regex,
-}
-
-impl<'a> Regex<'a> {
-  pub fn exp(&self) -> &swc_atoms::JsWord {
-    &self.inner.exp
-  }
-
-  pub fn flags(&self) -> &swc_atoms::JsWord {
-    &self.inner.flags
-  }
+  pub exp: &'a swc_atoms::JsWord,
+  pub flags: &'a swc_atoms::JsWord,
 }
 
 impl<'a> Spanned for Regex<'a> {
@@ -12421,6 +12253,8 @@ fn get_view_for_regex<'a>(inner: &'a swc_ast::Regex, parent: Node<'a>, bump: &'a
   let node = bump.alloc(Regex {
     inner,
     parent,
+    exp: &inner.exp,
+    flags: &inner.flags,
   });
   node
 }
@@ -12431,12 +12265,7 @@ pub struct RestPat<'a> {
   pub inner: &'a swc_ast::RestPat,
   pub arg: Pat<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-}
-
-impl<'a> RestPat<'a> {
-  pub fn dot3_token(&self) -> &swc_common::Span {
-    &self.inner.dot3_token
-  }
+  pub dot3_token: &'a swc_common::Span,
 }
 
 impl<'a> Spanned for RestPat<'a> {
@@ -12494,6 +12323,7 @@ fn get_view_for_rest_pat<'a>(inner: &'a swc_ast::RestPat, parent: Node<'a>, bump
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
+    dot3_token: &inner.dot3_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = get_view_for_pat(&inner.arg, parent.clone(), bump);
@@ -12578,12 +12408,7 @@ pub struct Script<'a> {
   pub comments: Option<&'a CommentContainer<'a>>,
   pub inner: &'a swc_ast::Script,
   pub body: Vec<Stmt<'a>>,
-}
-
-impl<'a> Script<'a> {
-  pub fn shebang(&self) -> &Option<swc_atoms::JsWord> {
-    &self.inner.shebang
-  }
+  pub shebang: &'a Option<swc_atoms::JsWord>,
 }
 
 impl<'a> Spanned for Script<'a> {
@@ -12648,6 +12473,7 @@ fn get_view_for_script<'a>(source_file_info: &'a ScriptInfo<'a>, bump: &'a Bump)
     tokens,
     comments,
     body: Vec::with_capacity(inner.body.len()),
+    shebang: &inner.shebang,
   });
   let parent: Node<'a> = (&*node).into();
   node.body.extend(inner.body.iter().map(|value| get_view_for_stmt(value, parent.clone(), bump)));
@@ -12799,12 +12625,7 @@ pub struct SpreadElement<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::SpreadElement,
   pub expr: Expr<'a>,
-}
-
-impl<'a> SpreadElement<'a> {
-  pub fn dot3_token(&self) -> &swc_common::Span {
-    &self.inner.dot3_token
-  }
+  pub dot3_token: &'a swc_common::Span,
 }
 
 impl<'a> Spanned for SpreadElement<'a> {
@@ -12858,6 +12679,7 @@ fn get_view_for_spread_element<'a>(inner: &'a swc_ast::SpreadElement, parent: No
     inner,
     parent,
     expr: unsafe { MaybeUninit::uninit().assume_init() },
+    dot3_token: &inner.dot3_token,
   });
   let parent: Node<'a> = (&*node).into();
   node.expr = get_view_for_expr(&inner.expr, parent, bump);
@@ -12867,21 +12689,10 @@ fn get_view_for_spread_element<'a>(inner: &'a swc_ast::SpreadElement, parent: No
 pub struct Str<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::Str,
-}
-
-impl<'a> Str<'a> {
-  pub fn value(&self) -> &swc_atoms::JsWord {
-    &self.inner.value
-  }
-
+  pub value: &'a swc_atoms::JsWord,
   /// This includes line escape.
-  pub fn has_escape(&self) -> bool {
-    self.inner.has_escape
-  }
-
-  pub fn kind(&self) -> StrKind {
-    self.inner.kind
-  }
+  pub has_escape: bool,
+  pub kind: StrKind,
 }
 
 impl<'a> Spanned for Str<'a> {
@@ -12932,6 +12743,9 @@ fn get_view_for_str<'a>(inner: &'a swc_ast::Str, parent: Node<'a>, bump: &'a Bum
   let node = bump.alloc(Str {
     inner,
     parent,
+    value: &inner.value,
+    has_escape: inner.has_escape,
+    kind: inner.kind,
   });
   node
 }
@@ -13417,12 +13231,7 @@ pub struct TplElement<'a> {
   pub inner: &'a swc_ast::TplElement,
   pub cooked: Option<&'a Str<'a>>,
   pub raw: &'a Str<'a>,
-}
-
-impl<'a> TplElement<'a> {
-  pub fn tail(&self) -> bool {
-    self.inner.tail
-  }
+  pub tail: bool,
 }
 
 impl<'a> Spanned for TplElement<'a> {
@@ -13480,6 +13289,7 @@ fn get_view_for_tpl_element<'a>(inner: &'a swc_ast::TplElement, parent: Node<'a>
     parent,
     cooked: None,
     raw: unsafe { MaybeUninit::uninit().assume_init() },
+    tail: inner.tail,
   });
   let parent: Node<'a> = (&*node).into();
   node.cooked = match &inner.cooked {
@@ -14011,12 +13821,7 @@ pub struct TsConstructorType<'a> {
   pub params: Vec<TsFnParam<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: &'a TsTypeAnn<'a>,
-}
-
-impl<'a> TsConstructorType<'a> {
-  pub fn is_abstract(&self) -> bool {
-    self.inner.is_abstract
-  }
+  pub is_abstract: bool,
 }
 
 impl<'a> Spanned for TsConstructorType<'a> {
@@ -14078,6 +13883,7 @@ fn get_view_for_ts_constructor_type<'a>(inner: &'a swc_ast::TsConstructorType, p
     params: Vec::with_capacity(inner.params.len()),
     type_params: None,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
+    is_abstract: inner.is_abstract,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_ts_fn_param(value, parent.clone(), bump)));
@@ -14094,16 +13900,8 @@ pub struct TsEnumDecl<'a> {
   pub inner: &'a swc_ast::TsEnumDecl,
   pub id: &'a Ident<'a>,
   pub members: Vec<&'a TsEnumMember<'a>>,
-}
-
-impl<'a> TsEnumDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
-
-  pub fn is_const(&self) -> bool {
-    self.inner.is_const
-  }
+  pub declare: bool,
+  pub is_const: bool,
 }
 
 impl<'a> Spanned for TsEnumDecl<'a> {
@@ -14161,6 +13959,8 @@ fn get_view_for_ts_enum_decl<'a>(inner: &'a swc_ast::TsEnumDecl, parent: Node<'a
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     members: Vec::with_capacity(inner.members.len()),
+    declare: inner.declare,
+    is_const: inner.is_const,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -14524,16 +14324,8 @@ pub struct TsImportEqualsDecl<'a> {
   pub inner: &'a swc_ast::TsImportEqualsDecl,
   pub id: &'a Ident<'a>,
   pub module_ref: TsModuleRef<'a>,
-}
-
-impl<'a> TsImportEqualsDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
-
-  pub fn is_export(&self) -> bool {
-    self.inner.is_export
-  }
+  pub declare: bool,
+  pub is_export: bool,
 }
 
 impl<'a> Spanned for TsImportEqualsDecl<'a> {
@@ -14589,6 +14381,8 @@ fn get_view_for_ts_import_equals_decl<'a>(inner: &'a swc_ast::TsImportEqualsDecl
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     module_ref: unsafe { MaybeUninit::uninit().assume_init() },
+    declare: inner.declare,
+    is_export: inner.is_export,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -14682,12 +14476,7 @@ pub struct TsIndexSignature<'a> {
   pub inner: &'a swc_ast::TsIndexSignature,
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-}
-
-impl<'a> TsIndexSignature<'a> {
-  pub fn readonly(&self) -> bool {
-    self.inner.readonly
-  }
+  pub readonly: bool,
 }
 
 impl<'a> Spanned for TsIndexSignature<'a> {
@@ -14747,6 +14536,7 @@ fn get_view_for_ts_index_signature<'a>(inner: &'a swc_ast::TsIndexSignature, par
     parent,
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
+    readonly: inner.readonly,
   });
   let parent: Node<'a> = (&*node).into();
   node.params.extend(inner.params.iter().map(|value| get_view_for_ts_fn_param(value, parent.clone(), bump)));
@@ -14762,12 +14552,7 @@ pub struct TsIndexedAccessType<'a> {
   pub inner: &'a swc_ast::TsIndexedAccessType,
   pub obj_type: TsType<'a>,
   pub index_type: TsType<'a>,
-}
-
-impl<'a> TsIndexedAccessType<'a> {
-  pub fn readonly(&self) -> bool {
-    self.inner.readonly
-  }
+  pub readonly: bool,
 }
 
 impl<'a> Spanned for TsIndexedAccessType<'a> {
@@ -14823,6 +14608,7 @@ fn get_view_for_ts_indexed_access_type<'a>(inner: &'a swc_ast::TsIndexedAccessTy
     parent,
     obj_type: unsafe { MaybeUninit::uninit().assume_init() },
     index_type: unsafe { MaybeUninit::uninit().assume_init() },
+    readonly: inner.readonly,
   });
   let parent: Node<'a> = (&*node).into();
   node.obj_type = get_view_for_ts_type(&inner.obj_type, parent.clone(), bump);
@@ -14965,12 +14751,7 @@ pub struct TsInterfaceDecl<'a> {
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub extends: Vec<&'a TsExprWithTypeArgs<'a>>,
   pub body: &'a TsInterfaceBody<'a>,
-}
-
-impl<'a> TsInterfaceDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
+  pub declare: bool,
 }
 
 impl<'a> Spanned for TsInterfaceDecl<'a> {
@@ -15034,6 +14815,7 @@ fn get_view_for_ts_interface_decl<'a>(inner: &'a swc_ast::TsInterfaceDecl, paren
     type_params: None,
     extends: Vec::with_capacity(inner.extends.len()),
     body: unsafe { MaybeUninit::uninit().assume_init() },
+    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -15114,12 +14896,7 @@ fn get_view_for_ts_intersection_type<'a>(inner: &'a swc_ast::TsIntersectionType,
 pub struct TsKeywordType<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::TsKeywordType,
-}
-
-impl<'a> TsKeywordType<'a> {
-  pub fn kind(&self) -> TsKeywordTypeKind {
-    self.inner.kind
-  }
+  pub kind: TsKeywordTypeKind,
 }
 
 impl<'a> Spanned for TsKeywordType<'a> {
@@ -15170,6 +14947,7 @@ fn get_view_for_ts_keyword_type<'a>(inner: &'a swc_ast::TsKeywordType, parent: N
   let node = bump.alloc(TsKeywordType {
     inner,
     parent,
+    kind: inner.kind,
   });
   node
 }
@@ -15243,16 +15021,8 @@ pub struct TsMappedType<'a> {
   pub type_param: &'a TsTypeParam<'a>,
   pub name_type: Option<TsType<'a>>,
   pub type_ann: Option<TsType<'a>>,
-}
-
-impl<'a> TsMappedType<'a> {
-  pub fn readonly(&self) -> Option<TruePlusMinus> {
-    self.inner.readonly
-  }
-
-  pub fn optional(&self) -> Option<TruePlusMinus> {
-    self.inner.optional
-  }
+  pub readonly: Option<TruePlusMinus>,
+  pub optional: Option<TruePlusMinus>,
 }
 
 impl<'a> Spanned for TsMappedType<'a> {
@@ -15314,6 +15084,8 @@ fn get_view_for_ts_mapped_type<'a>(inner: &'a swc_ast::TsMappedType, parent: Nod
     type_param: unsafe { MaybeUninit::uninit().assume_init() },
     name_type: None,
     type_ann: None,
+    readonly: inner.readonly,
+    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.type_param = get_view_for_ts_type_param(&inner.type_param, parent.clone(), bump);
@@ -15335,20 +15107,9 @@ pub struct TsMethodSignature<'a> {
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
-}
-
-impl<'a> TsMethodSignature<'a> {
-  pub fn readonly(&self) -> bool {
-    self.inner.readonly
-  }
-
-  pub fn computed(&self) -> bool {
-    self.inner.computed
-  }
-
-  pub fn optional(&self) -> bool {
-    self.inner.optional
-  }
+  pub readonly: bool,
+  pub computed: bool,
+  pub optional: bool,
 }
 
 impl<'a> Spanned for TsMethodSignature<'a> {
@@ -15414,6 +15175,9 @@ fn get_view_for_ts_method_signature<'a>(inner: &'a swc_ast::TsMethodSignature, p
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
     type_params: None,
+    readonly: inner.readonly,
+    computed: inner.computed,
+    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_expr(&inner.key, parent.clone(), bump);
@@ -15499,17 +15263,9 @@ pub struct TsModuleDecl<'a> {
   pub inner: &'a swc_ast::TsModuleDecl,
   pub id: TsModuleName<'a>,
   pub body: Option<TsNamespaceBody<'a>>,
-}
-
-impl<'a> TsModuleDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
-
+  pub declare: bool,
   /// In TypeScript, this is only available through`node.flags`.
-  pub fn global(&self) -> bool {
-    self.inner.global
-  }
+  pub global: bool,
 }
 
 impl<'a> Spanned for TsModuleDecl<'a> {
@@ -15567,6 +15323,8 @@ fn get_view_for_ts_module_decl<'a>(inner: &'a swc_ast::TsModuleDecl, parent: Nod
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     body: None,
+    declare: inner.declare,
+    global: inner.global,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ts_module_name(&inner.id, parent.clone(), bump);
@@ -15582,17 +15340,9 @@ pub struct TsNamespaceDecl<'a> {
   pub inner: &'a swc_ast::TsNamespaceDecl,
   pub id: &'a Ident<'a>,
   pub body: TsNamespaceBody<'a>,
-}
-
-impl<'a> TsNamespaceDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
-
+  pub declare: bool,
   /// In TypeScript, this is only available through`node.flags`.
-  pub fn global(&self) -> bool {
-    self.inner.global
-  }
+  pub global: bool,
 }
 
 impl<'a> Spanned for TsNamespaceDecl<'a> {
@@ -15648,6 +15398,8 @@ fn get_view_for_ts_namespace_decl<'a>(inner: &'a swc_ast::TsNamespaceDecl, paren
     parent,
     id: unsafe { MaybeUninit::uninit().assume_init() },
     body: unsafe { MaybeUninit::uninit().assume_init() },
+    declare: inner.declare,
+    global: inner.global,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -15849,17 +15601,9 @@ pub struct TsParamProp<'a> {
   pub inner: &'a swc_ast::TsParamProp,
   pub decorators: Vec<&'a Decorator<'a>>,
   pub param: TsParamPropParam<'a>,
-}
-
-impl<'a> TsParamProp<'a> {
   /// At least one of `accessibility` or `readonly` must be set.
-  pub fn accessibility(&self) -> Option<Accessibility> {
-    self.inner.accessibility
-  }
-
-  pub fn readonly(&self) -> bool {
-    self.inner.readonly
-  }
+  pub accessibility: Option<Accessibility>,
+  pub readonly: bool,
 }
 
 impl<'a> Spanned for TsParamProp<'a> {
@@ -15917,6 +15661,8 @@ fn get_view_for_ts_param_prop<'a>(inner: &'a swc_ast::TsParamProp, parent: Node<
     parent: parent.expect::<Constructor>(),
     decorators: Vec::with_capacity(inner.decorators.len()),
     param: unsafe { MaybeUninit::uninit().assume_init() },
+    accessibility: inner.accessibility,
+    readonly: inner.readonly,
   });
   let parent: Node<'a> = (&*node).into();
   node.decorators.extend(inner.decorators.iter().map(|value| get_view_for_decorator(value, parent.clone(), bump)));
@@ -15995,20 +15741,9 @@ pub struct TsPropertySignature<'a> {
   pub params: Vec<TsFnParam<'a>>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
-}
-
-impl<'a> TsPropertySignature<'a> {
-  pub fn readonly(&self) -> bool {
-    self.inner.readonly
-  }
-
-  pub fn computed(&self) -> bool {
-    self.inner.computed
-  }
-
-  pub fn optional(&self) -> bool {
-    self.inner.optional
-  }
+  pub readonly: bool,
+  pub computed: bool,
+  pub optional: bool,
 }
 
 impl<'a> Spanned for TsPropertySignature<'a> {
@@ -16078,6 +15813,9 @@ fn get_view_for_ts_property_signature<'a>(inner: &'a swc_ast::TsPropertySignatur
     params: Vec::with_capacity(inner.params.len()),
     type_ann: None,
     type_params: None,
+    readonly: inner.readonly,
+    computed: inner.computed,
+    optional: inner.optional,
   });
   let parent: Node<'a> = (&*node).into();
   node.key = get_view_for_expr(&inner.key, parent.clone(), bump);
@@ -16499,12 +16237,7 @@ pub struct TsTypeAliasDecl<'a> {
   pub id: &'a Ident<'a>,
   pub type_params: Option<&'a TsTypeParamDecl<'a>>,
   pub type_ann: TsType<'a>,
-}
-
-impl<'a> TsTypeAliasDecl<'a> {
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
+  pub declare: bool,
 }
 
 impl<'a> Spanned for TsTypeAliasDecl<'a> {
@@ -16564,6 +16297,7 @@ fn get_view_for_ts_type_alias_decl<'a>(inner: &'a swc_ast::TsTypeAliasDecl, pare
     id: unsafe { MaybeUninit::uninit().assume_init() },
     type_params: None,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
+    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.id = get_view_for_ident(&inner.id, parent.clone(), bump);
@@ -16774,12 +16508,7 @@ pub struct TsTypeOperator<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::TsTypeOperator,
   pub type_ann: TsType<'a>,
-}
-
-impl<'a> TsTypeOperator<'a> {
-  pub fn op(&self) -> TsTypeOperatorOp {
-    self.inner.op
-  }
+  pub op: TsTypeOperatorOp,
 }
 
 impl<'a> Spanned for TsTypeOperator<'a> {
@@ -16833,6 +16562,7 @@ fn get_view_for_ts_type_operator<'a>(inner: &'a swc_ast::TsTypeOperator, parent:
     inner,
     parent,
     type_ann: unsafe { MaybeUninit::uninit().assume_init() },
+    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.type_ann = get_view_for_ts_type(&inner.type_ann, parent, bump);
@@ -17055,12 +16785,7 @@ pub struct TsTypePredicate<'a> {
   pub inner: &'a swc_ast::TsTypePredicate,
   pub param_name: TsThisTypeOrIdent<'a>,
   pub type_ann: Option<&'a TsTypeAnn<'a>>,
-}
-
-impl<'a> TsTypePredicate<'a> {
-  pub fn asserts(&self) -> bool {
-    self.inner.asserts
-  }
+  pub asserts: bool,
 }
 
 impl<'a> Spanned for TsTypePredicate<'a> {
@@ -17118,6 +16843,7 @@ fn get_view_for_ts_type_predicate<'a>(inner: &'a swc_ast::TsTypePredicate, paren
     parent,
     param_name: unsafe { MaybeUninit::uninit().assume_init() },
     type_ann: None,
+    asserts: inner.asserts,
   });
   let parent: Node<'a> = (&*node).into();
   node.param_name = get_view_for_ts_this_type_or_ident(&inner.param_name, parent.clone(), bump);
@@ -17333,12 +17059,7 @@ pub struct UnaryExpr<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::UnaryExpr,
   pub arg: Expr<'a>,
-}
-
-impl<'a> UnaryExpr<'a> {
-  pub fn op(&self) -> UnaryOp {
-    self.inner.op
-  }
+  pub op: UnaryOp,
 }
 
 impl<'a> Spanned for UnaryExpr<'a> {
@@ -17392,6 +17113,7 @@ fn get_view_for_unary_expr<'a>(inner: &'a swc_ast::UnaryExpr, parent: Node<'a>, 
     inner,
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
+    op: inner.op,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = get_view_for_expr(&inner.arg, parent, bump);
@@ -17402,16 +17124,8 @@ pub struct UpdateExpr<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::UpdateExpr,
   pub arg: Expr<'a>,
-}
-
-impl<'a> UpdateExpr<'a> {
-  pub fn op(&self) -> UpdateOp {
-    self.inner.op
-  }
-
-  pub fn prefix(&self) -> bool {
-    self.inner.prefix
-  }
+  pub op: UpdateOp,
+  pub prefix: bool,
 }
 
 impl<'a> Spanned for UpdateExpr<'a> {
@@ -17465,6 +17179,8 @@ fn get_view_for_update_expr<'a>(inner: &'a swc_ast::UpdateExpr, parent: Node<'a>
     inner,
     parent,
     arg: unsafe { MaybeUninit::uninit().assume_init() },
+    op: inner.op,
+    prefix: inner.prefix,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = get_view_for_expr(&inner.arg, parent, bump);
@@ -17475,16 +17191,8 @@ pub struct VarDecl<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::VarDecl,
   pub decls: Vec<&'a VarDeclarator<'a>>,
-}
-
-impl<'a> VarDecl<'a> {
-  pub fn kind(&self) -> VarDeclKind {
-    self.inner.kind
-  }
-
-  pub fn declare(&self) -> bool {
-    self.inner.declare
-  }
+  pub kind: VarDeclKind,
+  pub declare: bool,
 }
 
 impl<'a> Spanned for VarDecl<'a> {
@@ -17540,6 +17248,8 @@ fn get_view_for_var_decl<'a>(inner: &'a swc_ast::VarDecl, parent: Node<'a>, bump
     inner,
     parent,
     decls: Vec::with_capacity(inner.decls.len()),
+    kind: inner.kind,
+    declare: inner.declare,
   });
   let parent: Node<'a> = (&*node).into();
   node.decls.extend(inner.decls.iter().map(|value| get_view_for_var_declarator(value, parent.clone(), bump)));
@@ -17552,13 +17262,8 @@ pub struct VarDeclarator<'a> {
   pub name: Pat<'a>,
   /// Initialization expression.
   pub init: Option<Expr<'a>>,
-}
-
-impl<'a> VarDeclarator<'a> {
   /// Typescript only
-  pub fn definite(&self) -> bool {
-    self.inner.definite
-  }
+  pub definite: bool,
 }
 
 impl<'a> Spanned for VarDeclarator<'a> {
@@ -17616,6 +17321,7 @@ fn get_view_for_var_declarator<'a>(inner: &'a swc_ast::VarDeclarator, parent: No
     parent: parent.expect::<VarDecl>(),
     name: unsafe { MaybeUninit::uninit().assume_init() },
     init: None,
+    definite: inner.definite,
   });
   let parent: Node<'a> = (&*node).into();
   node.name = get_view_for_pat(&inner.name, parent.clone(), bump);
@@ -17764,12 +17470,7 @@ pub struct YieldExpr<'a> {
   pub parent: Node<'a>,
   pub inner: &'a swc_ast::YieldExpr,
   pub arg: Option<Expr<'a>>,
-}
-
-impl<'a> YieldExpr<'a> {
-  pub fn delegate(&self) -> bool {
-    self.inner.delegate
-  }
+  pub delegate: bool,
 }
 
 impl<'a> Spanned for YieldExpr<'a> {
@@ -17825,6 +17526,7 @@ fn get_view_for_yield_expr<'a>(inner: &'a swc_ast::YieldExpr, parent: Node<'a>, 
     inner,
     parent,
     arg: None,
+    delegate: inner.delegate,
   });
   let parent: Node<'a> = (&*node).into();
   node.arg = match &inner.arg {

--- a/rs-lib/src/generated_serialize.rs
+++ b/rs-lib/src/generated_serialize.rs
@@ -1,0 +1,3794 @@
+// This code is code generated.
+// Run `./scripts/generate.sh` from the root directory to regenerate it.
+use std::marker::PhantomData;
+use serde::Serialize;
+use swc_common::{Span, Spanned};
+use crate::generated::*;
+
+#[derive(Serialize)]
+#[serde(rename = "ArrayLit", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableArrayLit<'a> {
+  span: Span,
+  elems: Vec<Option<&'a ExprOrSpread<'a>>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ArrayLit<'a>> for SerializableArrayLit<'a> {
+  fn from(orig: ArrayLit<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      elems: orig.elems,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ArrayPat", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableArrayPat<'a> {
+  span: Span,
+  optional: bool,
+  elems: Vec<Option<Pat<'a>>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ArrayPat<'a>> for SerializableArrayPat<'a> {
+  fn from(orig: ArrayPat<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      optional: orig.optional().clone(),
+      elems: orig.elems,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ArrowExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableArrowExpr<'a> {
+  span: Span,
+  is_async: bool,
+  is_generator: bool,
+  params: Vec<Pat<'a>>,
+  body: BlockStmtOrExpr<'a>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+  return_type: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ArrowExpr<'a>> for SerializableArrowExpr<'a> {
+  fn from(orig: ArrowExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      is_async: orig.is_async().clone(),
+      is_generator: orig.is_generator().clone(),
+      params: orig.params,
+      body: orig.body,
+      type_params: orig.type_params,
+      return_type: orig.return_type,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "AssignExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableAssignExpr<'a> {
+  span: Span,
+  op: AssignOp,
+  left: PatOrExpr<'a>,
+  right: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<AssignExpr<'a>> for SerializableAssignExpr<'a> {
+  fn from(orig: AssignExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      op: orig.op().clone(),
+      left: orig.left,
+      right: orig.right,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "AssignPat", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableAssignPat<'a> {
+  span: Span,
+  left: Pat<'a>,
+  right: Expr<'a>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<AssignPat<'a>> for SerializableAssignPat<'a> {
+  fn from(orig: AssignPat<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      left: orig.left,
+      right: orig.right,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "AssignPatProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableAssignPatProp<'a> {
+  span: Span,
+  key: &'a Ident<'a>,
+  value: Option<Expr<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<AssignPatProp<'a>> for SerializableAssignPatProp<'a> {
+  fn from(orig: AssignPatProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      key: orig.key,
+      value: orig.value,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "AssignProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableAssignProp<'a> {
+  span: Span,
+  key: &'a Ident<'a>,
+  value: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<AssignProp<'a>> for SerializableAssignProp<'a> {
+  fn from(orig: AssignProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      key: orig.key,
+      value: orig.value,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "AwaitExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableAwaitExpr<'a> {
+  span: Span,
+  arg: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<AwaitExpr<'a>> for SerializableAwaitExpr<'a> {
+  fn from(orig: AwaitExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      arg: orig.arg,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "BigInt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableBigInt<'a> {
+  span: Span,
+  value: num_bigint::BigInt,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<BigInt<'a>> for SerializableBigInt<'a> {
+  fn from(orig: BigInt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      value: orig.value().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "BinExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableBinExpr<'a> {
+  span: Span,
+  op: BinaryOp,
+  left: Expr<'a>,
+  right: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<BinExpr<'a>> for SerializableBinExpr<'a> {
+  fn from(orig: BinExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      op: orig.op().clone(),
+      left: orig.left,
+      right: orig.right,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "BindingIdent", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableBindingIdent<'a> {
+  span: Span,
+  id: &'a Ident<'a>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<BindingIdent<'a>> for SerializableBindingIdent<'a> {
+  fn from(orig: BindingIdent<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      id: orig.id,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "BlockStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableBlockStmt<'a> {
+  span: Span,
+  stmts: Vec<Stmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<BlockStmt<'a>> for SerializableBlockStmt<'a> {
+  fn from(orig: BlockStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      stmts: orig.stmts,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Bool", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableBool<'a> {
+  span: Span,
+  value: bool,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Bool<'a>> for SerializableBool<'a> {
+  fn from(orig: Bool<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      value: orig.value().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "BreakStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableBreakStmt<'a> {
+  span: Span,
+  label: Option<&'a Ident<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<BreakStmt<'a>> for SerializableBreakStmt<'a> {
+  fn from(orig: BreakStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      label: orig.label,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "CallExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableCallExpr<'a> {
+  span: Span,
+  callee: ExprOrSuper<'a>,
+  args: Vec<&'a ExprOrSpread<'a>>,
+  type_args: Option<&'a TsTypeParamInstantiation<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<CallExpr<'a>> for SerializableCallExpr<'a> {
+  fn from(orig: CallExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      callee: orig.callee,
+      args: orig.args,
+      type_args: orig.type_args,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "CatchClause", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableCatchClause<'a> {
+  span: Span,
+  param: Option<Pat<'a>>,
+  body: &'a BlockStmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<CatchClause<'a>> for SerializableCatchClause<'a> {
+  fn from(orig: CatchClause<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      param: orig.param,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Class", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableClass<'a> {
+  span: Span,
+  is_abstract: bool,
+  decorators: Vec<&'a Decorator<'a>>,
+  body: Vec<ClassMember<'a>>,
+  super_class: Option<Expr<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+  super_type_params: Option<&'a TsTypeParamInstantiation<'a>>,
+  implements: Vec<&'a TsExprWithTypeArgs<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Class<'a>> for SerializableClass<'a> {
+  fn from(orig: Class<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      is_abstract: orig.is_abstract().clone(),
+      decorators: orig.decorators,
+      body: orig.body,
+      super_class: orig.super_class,
+      type_params: orig.type_params,
+      super_type_params: orig.super_type_params,
+      implements: orig.implements,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ClassDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableClassDecl<'a> {
+  span: Span,
+  declare: bool,
+  ident: &'a Ident<'a>,
+  class: &'a Class<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ClassDecl<'a>> for SerializableClassDecl<'a> {
+  fn from(orig: ClassDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      ident: orig.ident,
+      class: orig.class,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ClassExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableClassExpr<'a> {
+  span: Span,
+  ident: Option<&'a Ident<'a>>,
+  class: &'a Class<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ClassExpr<'a>> for SerializableClassExpr<'a> {
+  fn from(orig: ClassExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      ident: orig.ident,
+      class: orig.class,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ClassMethod", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableClassMethod<'a> {
+  span: Span,
+  kind: MethodKind,
+  is_static: bool,
+  accessibility: Option<Accessibility>,
+  is_abstract: bool,
+  is_optional: bool,
+  key: PropName<'a>,
+  function: &'a Function<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ClassMethod<'a>> for SerializableClassMethod<'a> {
+  fn from(orig: ClassMethod<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      kind: orig.kind().clone(),
+      is_static: orig.is_static().clone(),
+      accessibility: orig.accessibility().clone(),
+      is_abstract: orig.is_abstract().clone(),
+      is_optional: orig.is_optional().clone(),
+      key: orig.key,
+      function: orig.function,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ClassProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableClassProp<'a> {
+  span: Span,
+  is_static: bool,
+  computed: bool,
+  accessibility: Option<Accessibility>,
+  is_abstract: bool,
+  is_optional: bool,
+  readonly: bool,
+  declare: bool,
+  definite: bool,
+  key: Expr<'a>,
+  value: Option<Expr<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+  decorators: Vec<&'a Decorator<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ClassProp<'a>> for SerializableClassProp<'a> {
+  fn from(orig: ClassProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      is_static: orig.is_static().clone(),
+      computed: orig.computed().clone(),
+      accessibility: orig.accessibility().clone(),
+      is_abstract: orig.is_abstract().clone(),
+      is_optional: orig.is_optional().clone(),
+      readonly: orig.readonly().clone(),
+      declare: orig.declare().clone(),
+      definite: orig.definite().clone(),
+      key: orig.key,
+      value: orig.value,
+      type_ann: orig.type_ann,
+      decorators: orig.decorators,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ComputedPropName", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableComputedPropName<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ComputedPropName<'a>> for SerializableComputedPropName<'a> {
+  fn from(orig: ComputedPropName<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "CondExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableCondExpr<'a> {
+  span: Span,
+  test: Expr<'a>,
+  cons: Expr<'a>,
+  alt: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<CondExpr<'a>> for SerializableCondExpr<'a> {
+  fn from(orig: CondExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      test: orig.test,
+      cons: orig.cons,
+      alt: orig.alt,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Constructor", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableConstructor<'a> {
+  span: Span,
+  accessibility: Option<Accessibility>,
+  is_optional: bool,
+  key: PropName<'a>,
+  params: Vec<ParamOrTsParamProp<'a>>,
+  body: Option<&'a BlockStmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Constructor<'a>> for SerializableConstructor<'a> {
+  fn from(orig: Constructor<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      accessibility: orig.accessibility().clone(),
+      is_optional: orig.is_optional().clone(),
+      key: orig.key,
+      params: orig.params,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ContinueStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableContinueStmt<'a> {
+  span: Span,
+  label: Option<&'a Ident<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ContinueStmt<'a>> for SerializableContinueStmt<'a> {
+  fn from(orig: ContinueStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      label: orig.label,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "DebuggerStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableDebuggerStmt<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<DebuggerStmt<'a>> for SerializableDebuggerStmt<'a> {
+  fn from(orig: DebuggerStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Decorator", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableDecorator<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Decorator<'a>> for SerializableDecorator<'a> {
+  fn from(orig: Decorator<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "DoWhileStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableDoWhileStmt<'a> {
+  span: Span,
+  test: Expr<'a>,
+  body: Stmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<DoWhileStmt<'a>> for SerializableDoWhileStmt<'a> {
+  fn from(orig: DoWhileStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      test: orig.test,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "EmptyStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableEmptyStmt<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<EmptyStmt<'a>> for SerializableEmptyStmt<'a> {
+  fn from(orig: EmptyStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExportAll", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExportAll<'a> {
+  span: Span,
+  src: &'a Str<'a>,
+  asserts: Option<&'a ObjectLit<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExportAll<'a>> for SerializableExportAll<'a> {
+  fn from(orig: ExportAll<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      src: orig.src,
+      asserts: orig.asserts,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExportDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExportDecl<'a> {
+  span: Span,
+  decl: Decl<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExportDecl<'a>> for SerializableExportDecl<'a> {
+  fn from(orig: ExportDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      decl: orig.decl,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExportDefaultDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExportDefaultDecl<'a> {
+  span: Span,
+  decl: DefaultDecl<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExportDefaultDecl<'a>> for SerializableExportDefaultDecl<'a> {
+  fn from(orig: ExportDefaultDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      decl: orig.decl,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExportDefaultExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExportDefaultExpr<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExportDefaultExpr<'a>> for SerializableExportDefaultExpr<'a> {
+  fn from(orig: ExportDefaultExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExportDefaultSpecifier", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExportDefaultSpecifier<'a> {
+  span: Span,
+  exported: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExportDefaultSpecifier<'a>> for SerializableExportDefaultSpecifier<'a> {
+  fn from(orig: ExportDefaultSpecifier<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      exported: orig.exported,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExportNamedSpecifier", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExportNamedSpecifier<'a> {
+  span: Span,
+  orig: &'a Ident<'a>,
+  exported: Option<&'a Ident<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExportNamedSpecifier<'a>> for SerializableExportNamedSpecifier<'a> {
+  fn from(orig: ExportNamedSpecifier<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      orig: orig.orig,
+      exported: orig.exported,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExportNamespaceSpecifier", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExportNamespaceSpecifier<'a> {
+  span: Span,
+  name: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExportNamespaceSpecifier<'a>> for SerializableExportNamespaceSpecifier<'a> {
+  fn from(orig: ExportNamespaceSpecifier<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      name: orig.name,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExprOrSpread", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExprOrSpread<'a> {
+  span: Span,
+  spread: Option<swc_common::Span>,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExprOrSpread<'a>> for SerializableExprOrSpread<'a> {
+  fn from(orig: ExprOrSpread<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      spread: orig.spread().clone(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ExprStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableExprStmt<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ExprStmt<'a>> for SerializableExprStmt<'a> {
+  fn from(orig: ExprStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "FnDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableFnDecl<'a> {
+  span: Span,
+  declare: bool,
+  ident: &'a Ident<'a>,
+  function: &'a Function<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<FnDecl<'a>> for SerializableFnDecl<'a> {
+  fn from(orig: FnDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      ident: orig.ident,
+      function: orig.function,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "FnExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableFnExpr<'a> {
+  span: Span,
+  ident: Option<&'a Ident<'a>>,
+  function: &'a Function<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<FnExpr<'a>> for SerializableFnExpr<'a> {
+  fn from(orig: FnExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      ident: orig.ident,
+      function: orig.function,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ForInStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableForInStmt<'a> {
+  span: Span,
+  left: VarDeclOrPat<'a>,
+  right: Expr<'a>,
+  body: Stmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ForInStmt<'a>> for SerializableForInStmt<'a> {
+  fn from(orig: ForInStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      left: orig.left,
+      right: orig.right,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ForOfStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableForOfStmt<'a> {
+  span: Span,
+  await_token: Option<swc_common::Span>,
+  left: VarDeclOrPat<'a>,
+  right: Expr<'a>,
+  body: Stmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ForOfStmt<'a>> for SerializableForOfStmt<'a> {
+  fn from(orig: ForOfStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      await_token: orig.await_token().clone(),
+      left: orig.left,
+      right: orig.right,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ForStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableForStmt<'a> {
+  span: Span,
+  init: Option<VarDeclOrExpr<'a>>,
+  test: Option<Expr<'a>>,
+  update: Option<Expr<'a>>,
+  body: Stmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ForStmt<'a>> for SerializableForStmt<'a> {
+  fn from(orig: ForStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      init: orig.init,
+      test: orig.test,
+      update: orig.update,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Function", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableFunction<'a> {
+  span: Span,
+  is_generator: bool,
+  is_async: bool,
+  params: Vec<&'a Param<'a>>,
+  decorators: Vec<&'a Decorator<'a>>,
+  body: Option<&'a BlockStmt<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+  return_type: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Function<'a>> for SerializableFunction<'a> {
+  fn from(orig: Function<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      is_generator: orig.is_generator().clone(),
+      is_async: orig.is_async().clone(),
+      params: orig.params,
+      decorators: orig.decorators,
+      body: orig.body,
+      type_params: orig.type_params,
+      return_type: orig.return_type,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "GetterProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableGetterProp<'a> {
+  span: Span,
+  key: PropName<'a>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+  body: Option<&'a BlockStmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<GetterProp<'a>> for SerializableGetterProp<'a> {
+  fn from(orig: GetterProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      key: orig.key,
+      type_ann: orig.type_ann,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Ident", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableIdent<'a> {
+  span: Span,
+  sym: swc_atoms::JsWord,
+  optional: bool,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Ident<'a>> for SerializableIdent<'a> {
+  fn from(orig: Ident<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      sym: orig.sym().clone(),
+      optional: orig.optional().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "IfStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableIfStmt<'a> {
+  span: Span,
+  test: Expr<'a>,
+  cons: Stmt<'a>,
+  alt: Option<Stmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<IfStmt<'a>> for SerializableIfStmt<'a> {
+  fn from(orig: IfStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      test: orig.test,
+      cons: orig.cons,
+      alt: orig.alt,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ImportDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableImportDecl<'a> {
+  span: Span,
+  type_only: bool,
+  specifiers: Vec<ImportSpecifier<'a>>,
+  src: &'a Str<'a>,
+  asserts: Option<&'a ObjectLit<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ImportDecl<'a>> for SerializableImportDecl<'a> {
+  fn from(orig: ImportDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_only: orig.type_only().clone(),
+      specifiers: orig.specifiers,
+      src: orig.src,
+      asserts: orig.asserts,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ImportDefaultSpecifier", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableImportDefaultSpecifier<'a> {
+  span: Span,
+  local: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ImportDefaultSpecifier<'a>> for SerializableImportDefaultSpecifier<'a> {
+  fn from(orig: ImportDefaultSpecifier<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      local: orig.local,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ImportNamedSpecifier", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableImportNamedSpecifier<'a> {
+  span: Span,
+  local: &'a Ident<'a>,
+  imported: Option<&'a Ident<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ImportNamedSpecifier<'a>> for SerializableImportNamedSpecifier<'a> {
+  fn from(orig: ImportNamedSpecifier<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      local: orig.local,
+      imported: orig.imported,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ImportStarAsSpecifier", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableImportStarAsSpecifier<'a> {
+  span: Span,
+  local: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ImportStarAsSpecifier<'a>> for SerializableImportStarAsSpecifier<'a> {
+  fn from(orig: ImportStarAsSpecifier<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      local: orig.local,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Invalid", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableInvalid<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Invalid<'a>> for SerializableInvalid<'a> {
+  fn from(orig: Invalid<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXAttr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXAttr<'a> {
+  span: Span,
+  name: JSXAttrName<'a>,
+  value: Option<JSXAttrValue<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXAttr<'a>> for SerializableJSXAttr<'a> {
+  fn from(orig: JSXAttr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      name: orig.name,
+      value: orig.value,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXClosingElement", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXClosingElement<'a> {
+  span: Span,
+  name: JSXElementName<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXClosingElement<'a>> for SerializableJSXClosingElement<'a> {
+  fn from(orig: JSXClosingElement<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      name: orig.name,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXClosingFragment", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXClosingFragment<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXClosingFragment<'a>> for SerializableJSXClosingFragment<'a> {
+  fn from(orig: JSXClosingFragment<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXElement", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXElement<'a> {
+  span: Span,
+  opening: &'a JSXOpeningElement<'a>,
+  children: Vec<JSXElementChild<'a>>,
+  closing: Option<&'a JSXClosingElement<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXElement<'a>> for SerializableJSXElement<'a> {
+  fn from(orig: JSXElement<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      opening: orig.opening,
+      children: orig.children,
+      closing: orig.closing,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXEmptyExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXEmptyExpr<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXEmptyExpr<'a>> for SerializableJSXEmptyExpr<'a> {
+  fn from(orig: JSXEmptyExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXExprContainer", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXExprContainer<'a> {
+  span: Span,
+  expr: JSXExpr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXExprContainer<'a>> for SerializableJSXExprContainer<'a> {
+  fn from(orig: JSXExprContainer<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXFragment", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXFragment<'a> {
+  span: Span,
+  opening: &'a JSXOpeningFragment<'a>,
+  children: Vec<JSXElementChild<'a>>,
+  closing: &'a JSXClosingFragment<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXFragment<'a>> for SerializableJSXFragment<'a> {
+  fn from(orig: JSXFragment<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      opening: orig.opening,
+      children: orig.children,
+      closing: orig.closing,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXMemberExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXMemberExpr<'a> {
+  span: Span,
+  obj: JSXObject<'a>,
+  prop: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXMemberExpr<'a>> for SerializableJSXMemberExpr<'a> {
+  fn from(orig: JSXMemberExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      obj: orig.obj,
+      prop: orig.prop,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXNamespacedName", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXNamespacedName<'a> {
+  span: Span,
+  ns: &'a Ident<'a>,
+  name: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXNamespacedName<'a>> for SerializableJSXNamespacedName<'a> {
+  fn from(orig: JSXNamespacedName<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      ns: orig.ns,
+      name: orig.name,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXOpeningElement", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXOpeningElement<'a> {
+  span: Span,
+  self_closing: bool,
+  name: JSXElementName<'a>,
+  attrs: Vec<JSXAttrOrSpread<'a>>,
+  type_args: Option<&'a TsTypeParamInstantiation<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXOpeningElement<'a>> for SerializableJSXOpeningElement<'a> {
+  fn from(orig: JSXOpeningElement<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      self_closing: orig.self_closing().clone(),
+      name: orig.name,
+      attrs: orig.attrs,
+      type_args: orig.type_args,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXOpeningFragment", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXOpeningFragment<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXOpeningFragment<'a>> for SerializableJSXOpeningFragment<'a> {
+  fn from(orig: JSXOpeningFragment<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXSpreadChild", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXSpreadChild<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXSpreadChild<'a>> for SerializableJSXSpreadChild<'a> {
+  fn from(orig: JSXSpreadChild<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "JSXText", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableJSXText<'a> {
+  span: Span,
+  value: swc_atoms::JsWord,
+  raw: swc_atoms::JsWord,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<JSXText<'a>> for SerializableJSXText<'a> {
+  fn from(orig: JSXText<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      value: orig.value().clone(),
+      raw: orig.raw().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "KeyValuePatProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableKeyValuePatProp<'a> {
+  span: Span,
+  key: PropName<'a>,
+  value: Pat<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<KeyValuePatProp<'a>> for SerializableKeyValuePatProp<'a> {
+  fn from(orig: KeyValuePatProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      key: orig.key,
+      value: orig.value,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "KeyValueProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableKeyValueProp<'a> {
+  span: Span,
+  key: PropName<'a>,
+  value: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<KeyValueProp<'a>> for SerializableKeyValueProp<'a> {
+  fn from(orig: KeyValueProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      key: orig.key,
+      value: orig.value,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "LabeledStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableLabeledStmt<'a> {
+  span: Span,
+  label: &'a Ident<'a>,
+  body: Stmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<LabeledStmt<'a>> for SerializableLabeledStmt<'a> {
+  fn from(orig: LabeledStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      label: orig.label,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "MemberExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableMemberExpr<'a> {
+  span: Span,
+  computed: bool,
+  obj: ExprOrSuper<'a>,
+  prop: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<MemberExpr<'a>> for SerializableMemberExpr<'a> {
+  fn from(orig: MemberExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      computed: orig.computed().clone(),
+      obj: orig.obj,
+      prop: orig.prop,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "MetaPropExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableMetaPropExpr<'a> {
+  span: Span,
+  meta: &'a Ident<'a>,
+  prop: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<MetaPropExpr<'a>> for SerializableMetaPropExpr<'a> {
+  fn from(orig: MetaPropExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      meta: orig.meta,
+      prop: orig.prop,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "MethodProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableMethodProp<'a> {
+  span: Span,
+  key: PropName<'a>,
+  function: &'a Function<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<MethodProp<'a>> for SerializableMethodProp<'a> {
+  fn from(orig: MethodProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      key: orig.key,
+      function: orig.function,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Module", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableModule<'a> {
+  span: Span,
+  shebang: Option<swc_atoms::JsWord>,
+  body: Vec<ModuleItem<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Module<'a>> for SerializableModule<'a> {
+  fn from(orig: Module<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      shebang: orig.shebang().clone(),
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "NamedExport", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableNamedExport<'a> {
+  span: Span,
+  type_only: bool,
+  specifiers: Vec<ExportSpecifier<'a>>,
+  src: Option<&'a Str<'a>>,
+  asserts: Option<&'a ObjectLit<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<NamedExport<'a>> for SerializableNamedExport<'a> {
+  fn from(orig: NamedExport<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_only: orig.type_only().clone(),
+      specifiers: orig.specifiers,
+      src: orig.src,
+      asserts: orig.asserts,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "NewExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableNewExpr<'a> {
+  span: Span,
+  callee: Expr<'a>,
+  args: Option<Vec<&'a ExprOrSpread<'a>>>,
+  type_args: Option<&'a TsTypeParamInstantiation<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<NewExpr<'a>> for SerializableNewExpr<'a> {
+  fn from(orig: NewExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      callee: orig.callee,
+      args: orig.args,
+      type_args: orig.type_args,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Null", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableNull<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Null<'a>> for SerializableNull<'a> {
+  fn from(orig: Null<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Number", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableNumber<'a> {
+  span: Span,
+  value: f64,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Number<'a>> for SerializableNumber<'a> {
+  fn from(orig: Number<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      value: orig.value().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ObjectLit", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableObjectLit<'a> {
+  span: Span,
+  props: Vec<PropOrSpread<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ObjectLit<'a>> for SerializableObjectLit<'a> {
+  fn from(orig: ObjectLit<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      props: orig.props,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ObjectPat", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableObjectPat<'a> {
+  span: Span,
+  optional: bool,
+  props: Vec<ObjectPatProp<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ObjectPat<'a>> for SerializableObjectPat<'a> {
+  fn from(orig: ObjectPat<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      optional: orig.optional().clone(),
+      props: orig.props,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "OptChainExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableOptChainExpr<'a> {
+  span: Span,
+  question_dot_token: swc_common::Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<OptChainExpr<'a>> for SerializableOptChainExpr<'a> {
+  fn from(orig: OptChainExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      question_dot_token: orig.question_dot_token().clone(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Param", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableParam<'a> {
+  span: Span,
+  decorators: Vec<&'a Decorator<'a>>,
+  pat: Pat<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Param<'a>> for SerializableParam<'a> {
+  fn from(orig: Param<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      decorators: orig.decorators,
+      pat: orig.pat,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ParenExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableParenExpr<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ParenExpr<'a>> for SerializableParenExpr<'a> {
+  fn from(orig: ParenExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "PrivateMethod", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializablePrivateMethod<'a> {
+  span: Span,
+  kind: MethodKind,
+  is_static: bool,
+  accessibility: Option<Accessibility>,
+  is_abstract: bool,
+  is_optional: bool,
+  key: &'a PrivateName<'a>,
+  function: &'a Function<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<PrivateMethod<'a>> for SerializablePrivateMethod<'a> {
+  fn from(orig: PrivateMethod<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      kind: orig.kind().clone(),
+      is_static: orig.is_static().clone(),
+      accessibility: orig.accessibility().clone(),
+      is_abstract: orig.is_abstract().clone(),
+      is_optional: orig.is_optional().clone(),
+      key: orig.key,
+      function: orig.function,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "PrivateName", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializablePrivateName<'a> {
+  span: Span,
+  id: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<PrivateName<'a>> for SerializablePrivateName<'a> {
+  fn from(orig: PrivateName<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      id: orig.id,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "PrivateProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializablePrivateProp<'a> {
+  span: Span,
+  is_static: bool,
+  computed: bool,
+  accessibility: Option<Accessibility>,
+  is_abstract: bool,
+  is_optional: bool,
+  readonly: bool,
+  definite: bool,
+  key: &'a PrivateName<'a>,
+  value: Option<Expr<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+  decorators: Vec<&'a Decorator<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<PrivateProp<'a>> for SerializablePrivateProp<'a> {
+  fn from(orig: PrivateProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      is_static: orig.is_static().clone(),
+      computed: orig.computed().clone(),
+      accessibility: orig.accessibility().clone(),
+      is_abstract: orig.is_abstract().clone(),
+      is_optional: orig.is_optional().clone(),
+      readonly: orig.readonly().clone(),
+      definite: orig.definite().clone(),
+      key: orig.key,
+      value: orig.value,
+      type_ann: orig.type_ann,
+      decorators: orig.decorators,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Regex", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableRegex<'a> {
+  span: Span,
+  exp: swc_atoms::JsWord,
+  flags: swc_atoms::JsWord,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Regex<'a>> for SerializableRegex<'a> {
+  fn from(orig: Regex<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      exp: orig.exp().clone(),
+      flags: orig.flags().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "RestPat", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableRestPat<'a> {
+  span: Span,
+  dot3_token: swc_common::Span,
+  arg: Pat<'a>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<RestPat<'a>> for SerializableRestPat<'a> {
+  fn from(orig: RestPat<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      dot3_token: orig.dot3_token().clone(),
+      arg: orig.arg,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ReturnStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableReturnStmt<'a> {
+  span: Span,
+  arg: Option<Expr<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ReturnStmt<'a>> for SerializableReturnStmt<'a> {
+  fn from(orig: ReturnStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      arg: orig.arg,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Script", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableScript<'a> {
+  span: Span,
+  shebang: Option<swc_atoms::JsWord>,
+  body: Vec<Stmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Script<'a>> for SerializableScript<'a> {
+  fn from(orig: Script<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      shebang: orig.shebang().clone(),
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "SeqExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableSeqExpr<'a> {
+  span: Span,
+  exprs: Vec<Expr<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<SeqExpr<'a>> for SerializableSeqExpr<'a> {
+  fn from(orig: SeqExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      exprs: orig.exprs,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "SetterProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableSetterProp<'a> {
+  span: Span,
+  key: PropName<'a>,
+  param: Pat<'a>,
+  body: Option<&'a BlockStmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<SetterProp<'a>> for SerializableSetterProp<'a> {
+  fn from(orig: SetterProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      key: orig.key,
+      param: orig.param,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "SpreadElement", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableSpreadElement<'a> {
+  span: Span,
+  dot3_token: swc_common::Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<SpreadElement<'a>> for SerializableSpreadElement<'a> {
+  fn from(orig: SpreadElement<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      dot3_token: orig.dot3_token().clone(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Str", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableStr<'a> {
+  span: Span,
+  value: swc_atoms::JsWord,
+  has_escape: bool,
+  kind: StrKind,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Str<'a>> for SerializableStr<'a> {
+  fn from(orig: Str<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      value: orig.value().clone(),
+      has_escape: orig.has_escape().clone(),
+      kind: orig.kind().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Super", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableSuper<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Super<'a>> for SerializableSuper<'a> {
+  fn from(orig: Super<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "SwitchCase", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableSwitchCase<'a> {
+  span: Span,
+  test: Option<Expr<'a>>,
+  cons: Vec<Stmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<SwitchCase<'a>> for SerializableSwitchCase<'a> {
+  fn from(orig: SwitchCase<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      test: orig.test,
+      cons: orig.cons,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "SwitchStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableSwitchStmt<'a> {
+  span: Span,
+  discriminant: Expr<'a>,
+  cases: Vec<&'a SwitchCase<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<SwitchStmt<'a>> for SerializableSwitchStmt<'a> {
+  fn from(orig: SwitchStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      discriminant: orig.discriminant,
+      cases: orig.cases,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TaggedTpl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTaggedTpl<'a> {
+  span: Span,
+  tag: Expr<'a>,
+  exprs: Vec<Expr<'a>>,
+  quasis: Vec<&'a TplElement<'a>>,
+  type_params: Option<&'a TsTypeParamInstantiation<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TaggedTpl<'a>> for SerializableTaggedTpl<'a> {
+  fn from(orig: TaggedTpl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      tag: orig.tag,
+      exprs: orig.exprs,
+      quasis: orig.quasis,
+      type_params: orig.type_params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ThisExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableThisExpr<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ThisExpr<'a>> for SerializableThisExpr<'a> {
+  fn from(orig: ThisExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "ThrowStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableThrowStmt<'a> {
+  span: Span,
+  arg: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<ThrowStmt<'a>> for SerializableThrowStmt<'a> {
+  fn from(orig: ThrowStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      arg: orig.arg,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Tpl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTpl<'a> {
+  span: Span,
+  exprs: Vec<Expr<'a>>,
+  quasis: Vec<&'a TplElement<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<Tpl<'a>> for SerializableTpl<'a> {
+  fn from(orig: Tpl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      exprs: orig.exprs,
+      quasis: orig.quasis,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TplElement", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTplElement<'a> {
+  span: Span,
+  tail: bool,
+  cooked: Option<&'a Str<'a>>,
+  raw: &'a Str<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TplElement<'a>> for SerializableTplElement<'a> {
+  fn from(orig: TplElement<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      tail: orig.tail().clone(),
+      cooked: orig.cooked,
+      raw: orig.raw,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TryStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTryStmt<'a> {
+  span: Span,
+  block: &'a BlockStmt<'a>,
+  handler: Option<&'a CatchClause<'a>>,
+  finalizer: Option<&'a BlockStmt<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TryStmt<'a>> for SerializableTryStmt<'a> {
+  fn from(orig: TryStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      block: orig.block,
+      handler: orig.handler,
+      finalizer: orig.finalizer,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsArrayType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsArrayType<'a> {
+  span: Span,
+  elem_type: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsArrayType<'a>> for SerializableTsArrayType<'a> {
+  fn from(orig: TsArrayType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      elem_type: orig.elem_type,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsAsExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsAsExpr<'a> {
+  span: Span,
+  expr: Expr<'a>,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsAsExpr<'a>> for SerializableTsAsExpr<'a> {
+  fn from(orig: TsAsExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsCallSignatureDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsCallSignatureDecl<'a> {
+  span: Span,
+  params: Vec<TsFnParam<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsCallSignatureDecl<'a>> for SerializableTsCallSignatureDecl<'a> {
+  fn from(orig: TsCallSignatureDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      params: orig.params,
+      type_ann: orig.type_ann,
+      type_params: orig.type_params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsConditionalType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsConditionalType<'a> {
+  span: Span,
+  check_type: TsType<'a>,
+  extends_type: TsType<'a>,
+  true_type: TsType<'a>,
+  false_type: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsConditionalType<'a>> for SerializableTsConditionalType<'a> {
+  fn from(orig: TsConditionalType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      check_type: orig.check_type,
+      extends_type: orig.extends_type,
+      true_type: orig.true_type,
+      false_type: orig.false_type,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsConstAssertion", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsConstAssertion<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsConstAssertion<'a>> for SerializableTsConstAssertion<'a> {
+  fn from(orig: TsConstAssertion<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsConstructSignatureDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsConstructSignatureDecl<'a> {
+  span: Span,
+  params: Vec<TsFnParam<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsConstructSignatureDecl<'a>> for SerializableTsConstructSignatureDecl<'a> {
+  fn from(orig: TsConstructSignatureDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      params: orig.params,
+      type_ann: orig.type_ann,
+      type_params: orig.type_params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsConstructorType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsConstructorType<'a> {
+  span: Span,
+  is_abstract: bool,
+  params: Vec<TsFnParam<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+  type_ann: &'a TsTypeAnn<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsConstructorType<'a>> for SerializableTsConstructorType<'a> {
+  fn from(orig: TsConstructorType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      is_abstract: orig.is_abstract().clone(),
+      params: orig.params,
+      type_params: orig.type_params,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsEnumDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsEnumDecl<'a> {
+  span: Span,
+  declare: bool,
+  is_const: bool,
+  id: &'a Ident<'a>,
+  members: Vec<&'a TsEnumMember<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsEnumDecl<'a>> for SerializableTsEnumDecl<'a> {
+  fn from(orig: TsEnumDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      is_const: orig.is_const().clone(),
+      id: orig.id,
+      members: orig.members,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsEnumMember", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsEnumMember<'a> {
+  span: Span,
+  id: TsEnumMemberId<'a>,
+  init: Option<Expr<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsEnumMember<'a>> for SerializableTsEnumMember<'a> {
+  fn from(orig: TsEnumMember<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      id: orig.id,
+      init: orig.init,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsExportAssignment", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsExportAssignment<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsExportAssignment<'a>> for SerializableTsExportAssignment<'a> {
+  fn from(orig: TsExportAssignment<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsExprWithTypeArgs", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsExprWithTypeArgs<'a> {
+  span: Span,
+  expr: TsEntityName<'a>,
+  type_args: Option<&'a TsTypeParamInstantiation<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsExprWithTypeArgs<'a>> for SerializableTsExprWithTypeArgs<'a> {
+  fn from(orig: TsExprWithTypeArgs<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      type_args: orig.type_args,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsExternalModuleRef", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsExternalModuleRef<'a> {
+  span: Span,
+  expr: &'a Str<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsExternalModuleRef<'a>> for SerializableTsExternalModuleRef<'a> {
+  fn from(orig: TsExternalModuleRef<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsFnType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsFnType<'a> {
+  span: Span,
+  params: Vec<TsFnParam<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+  type_ann: &'a TsTypeAnn<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsFnType<'a>> for SerializableTsFnType<'a> {
+  fn from(orig: TsFnType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      params: orig.params,
+      type_params: orig.type_params,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsImportEqualsDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsImportEqualsDecl<'a> {
+  span: Span,
+  declare: bool,
+  is_export: bool,
+  id: &'a Ident<'a>,
+  module_ref: TsModuleRef<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsImportEqualsDecl<'a>> for SerializableTsImportEqualsDecl<'a> {
+  fn from(orig: TsImportEqualsDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      is_export: orig.is_export().clone(),
+      id: orig.id,
+      module_ref: orig.module_ref,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsImportType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsImportType<'a> {
+  span: Span,
+  arg: &'a Str<'a>,
+  qualifier: Option<TsEntityName<'a>>,
+  type_args: Option<&'a TsTypeParamInstantiation<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsImportType<'a>> for SerializableTsImportType<'a> {
+  fn from(orig: TsImportType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      arg: orig.arg,
+      qualifier: orig.qualifier,
+      type_args: orig.type_args,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsIndexSignature", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsIndexSignature<'a> {
+  span: Span,
+  readonly: bool,
+  params: Vec<TsFnParam<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsIndexSignature<'a>> for SerializableTsIndexSignature<'a> {
+  fn from(orig: TsIndexSignature<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      readonly: orig.readonly().clone(),
+      params: orig.params,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsIndexedAccessType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsIndexedAccessType<'a> {
+  span: Span,
+  readonly: bool,
+  obj_type: TsType<'a>,
+  index_type: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsIndexedAccessType<'a>> for SerializableTsIndexedAccessType<'a> {
+  fn from(orig: TsIndexedAccessType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      readonly: orig.readonly().clone(),
+      obj_type: orig.obj_type,
+      index_type: orig.index_type,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsInferType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsInferType<'a> {
+  span: Span,
+  type_param: &'a TsTypeParam<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsInferType<'a>> for SerializableTsInferType<'a> {
+  fn from(orig: TsInferType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_param: orig.type_param,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsInterfaceBody", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsInterfaceBody<'a> {
+  span: Span,
+  body: Vec<TsTypeElement<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsInterfaceBody<'a>> for SerializableTsInterfaceBody<'a> {
+  fn from(orig: TsInterfaceBody<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsInterfaceDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsInterfaceDecl<'a> {
+  span: Span,
+  declare: bool,
+  id: &'a Ident<'a>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+  extends: Vec<&'a TsExprWithTypeArgs<'a>>,
+  body: &'a TsInterfaceBody<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsInterfaceDecl<'a>> for SerializableTsInterfaceDecl<'a> {
+  fn from(orig: TsInterfaceDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      id: orig.id,
+      type_params: orig.type_params,
+      extends: orig.extends,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsIntersectionType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsIntersectionType<'a> {
+  span: Span,
+  types: Vec<TsType<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsIntersectionType<'a>> for SerializableTsIntersectionType<'a> {
+  fn from(orig: TsIntersectionType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      types: orig.types,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsKeywordType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsKeywordType<'a> {
+  span: Span,
+  kind: TsKeywordTypeKind,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsKeywordType<'a>> for SerializableTsKeywordType<'a> {
+  fn from(orig: TsKeywordType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      kind: orig.kind().clone(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsLitType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsLitType<'a> {
+  span: Span,
+  lit: TsLit<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsLitType<'a>> for SerializableTsLitType<'a> {
+  fn from(orig: TsLitType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      lit: orig.lit,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsMappedType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsMappedType<'a> {
+  span: Span,
+  readonly: Option<TruePlusMinus>,
+  optional: Option<TruePlusMinus>,
+  type_param: &'a TsTypeParam<'a>,
+  name_type: Option<TsType<'a>>,
+  type_ann: Option<TsType<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsMappedType<'a>> for SerializableTsMappedType<'a> {
+  fn from(orig: TsMappedType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      readonly: orig.readonly().clone(),
+      optional: orig.optional().clone(),
+      type_param: orig.type_param,
+      name_type: orig.name_type,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsMethodSignature", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsMethodSignature<'a> {
+  span: Span,
+  readonly: bool,
+  computed: bool,
+  optional: bool,
+  key: Expr<'a>,
+  params: Vec<TsFnParam<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsMethodSignature<'a>> for SerializableTsMethodSignature<'a> {
+  fn from(orig: TsMethodSignature<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      readonly: orig.readonly().clone(),
+      computed: orig.computed().clone(),
+      optional: orig.optional().clone(),
+      key: orig.key,
+      params: orig.params,
+      type_ann: orig.type_ann,
+      type_params: orig.type_params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsModuleBlock", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsModuleBlock<'a> {
+  span: Span,
+  body: Vec<ModuleItem<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsModuleBlock<'a>> for SerializableTsModuleBlock<'a> {
+  fn from(orig: TsModuleBlock<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsModuleDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsModuleDecl<'a> {
+  span: Span,
+  declare: bool,
+  global: bool,
+  id: TsModuleName<'a>,
+  body: Option<TsNamespaceBody<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsModuleDecl<'a>> for SerializableTsModuleDecl<'a> {
+  fn from(orig: TsModuleDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      global: orig.global().clone(),
+      id: orig.id,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsNamespaceDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsNamespaceDecl<'a> {
+  span: Span,
+  declare: bool,
+  global: bool,
+  id: &'a Ident<'a>,
+  body: TsNamespaceBody<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsNamespaceDecl<'a>> for SerializableTsNamespaceDecl<'a> {
+  fn from(orig: TsNamespaceDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      global: orig.global().clone(),
+      id: orig.id,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsNamespaceExportDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsNamespaceExportDecl<'a> {
+  span: Span,
+  id: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsNamespaceExportDecl<'a>> for SerializableTsNamespaceExportDecl<'a> {
+  fn from(orig: TsNamespaceExportDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      id: orig.id,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsNonNullExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsNonNullExpr<'a> {
+  span: Span,
+  expr: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsNonNullExpr<'a>> for SerializableTsNonNullExpr<'a> {
+  fn from(orig: TsNonNullExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsOptionalType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsOptionalType<'a> {
+  span: Span,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsOptionalType<'a>> for SerializableTsOptionalType<'a> {
+  fn from(orig: TsOptionalType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsParamProp", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsParamProp<'a> {
+  span: Span,
+  accessibility: Option<Accessibility>,
+  readonly: bool,
+  decorators: Vec<&'a Decorator<'a>>,
+  param: TsParamPropParam<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsParamProp<'a>> for SerializableTsParamProp<'a> {
+  fn from(orig: TsParamProp<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      accessibility: orig.accessibility().clone(),
+      readonly: orig.readonly().clone(),
+      decorators: orig.decorators,
+      param: orig.param,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsParenthesizedType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsParenthesizedType<'a> {
+  span: Span,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsParenthesizedType<'a>> for SerializableTsParenthesizedType<'a> {
+  fn from(orig: TsParenthesizedType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsPropertySignature", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsPropertySignature<'a> {
+  span: Span,
+  readonly: bool,
+  computed: bool,
+  optional: bool,
+  key: Expr<'a>,
+  init: Option<Expr<'a>>,
+  params: Vec<TsFnParam<'a>>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsPropertySignature<'a>> for SerializableTsPropertySignature<'a> {
+  fn from(orig: TsPropertySignature<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      readonly: orig.readonly().clone(),
+      computed: orig.computed().clone(),
+      optional: orig.optional().clone(),
+      key: orig.key,
+      init: orig.init,
+      params: orig.params,
+      type_ann: orig.type_ann,
+      type_params: orig.type_params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsQualifiedName", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsQualifiedName<'a> {
+  span: Span,
+  left: TsEntityName<'a>,
+  right: &'a Ident<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsQualifiedName<'a>> for SerializableTsQualifiedName<'a> {
+  fn from(orig: TsQualifiedName<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      left: orig.left,
+      right: orig.right,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsRestType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsRestType<'a> {
+  span: Span,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsRestType<'a>> for SerializableTsRestType<'a> {
+  fn from(orig: TsRestType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsThisType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsThisType<'a> {
+  span: Span,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsThisType<'a>> for SerializableTsThisType<'a> {
+  fn from(orig: TsThisType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTplLitType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTplLitType<'a> {
+  span: Span,
+  types: Vec<TsType<'a>>,
+  quasis: Vec<&'a TplElement<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTplLitType<'a>> for SerializableTsTplLitType<'a> {
+  fn from(orig: TsTplLitType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      types: orig.types,
+      quasis: orig.quasis,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTupleElement", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTupleElement<'a> {
+  span: Span,
+  label: Option<Pat<'a>>,
+  ty: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTupleElement<'a>> for SerializableTsTupleElement<'a> {
+  fn from(orig: TsTupleElement<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      label: orig.label,
+      ty: orig.ty,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTupleType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTupleType<'a> {
+  span: Span,
+  elem_types: Vec<&'a TsTupleElement<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTupleType<'a>> for SerializableTsTupleType<'a> {
+  fn from(orig: TsTupleType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      elem_types: orig.elem_types,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeAliasDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeAliasDecl<'a> {
+  span: Span,
+  declare: bool,
+  id: &'a Ident<'a>,
+  type_params: Option<&'a TsTypeParamDecl<'a>>,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeAliasDecl<'a>> for SerializableTsTypeAliasDecl<'a> {
+  fn from(orig: TsTypeAliasDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      declare: orig.declare().clone(),
+      id: orig.id,
+      type_params: orig.type_params,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeAnn", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeAnn<'a> {
+  span: Span,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeAnn<'a>> for SerializableTsTypeAnn<'a> {
+  fn from(orig: TsTypeAnn<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeAssertion", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeAssertion<'a> {
+  span: Span,
+  expr: Expr<'a>,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeAssertion<'a>> for SerializableTsTypeAssertion<'a> {
+  fn from(orig: TsTypeAssertion<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr: orig.expr,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeLit", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeLit<'a> {
+  span: Span,
+  members: Vec<TsTypeElement<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeLit<'a>> for SerializableTsTypeLit<'a> {
+  fn from(orig: TsTypeLit<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      members: orig.members,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeOperator", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeOperator<'a> {
+  span: Span,
+  op: TsTypeOperatorOp,
+  type_ann: TsType<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeOperator<'a>> for SerializableTsTypeOperator<'a> {
+  fn from(orig: TsTypeOperator<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      op: orig.op().clone(),
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeParam", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeParam<'a> {
+  span: Span,
+  name: &'a Ident<'a>,
+  constraint: Option<TsType<'a>>,
+  default: Option<TsType<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeParam<'a>> for SerializableTsTypeParam<'a> {
+  fn from(orig: TsTypeParam<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      name: orig.name,
+      constraint: orig.constraint,
+      default: orig.default,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeParamDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeParamDecl<'a> {
+  span: Span,
+  params: Vec<&'a TsTypeParam<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeParamDecl<'a>> for SerializableTsTypeParamDecl<'a> {
+  fn from(orig: TsTypeParamDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      params: orig.params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeParamInstantiation", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeParamInstantiation<'a> {
+  span: Span,
+  params: Vec<TsType<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeParamInstantiation<'a>> for SerializableTsTypeParamInstantiation<'a> {
+  fn from(orig: TsTypeParamInstantiation<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      params: orig.params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypePredicate", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypePredicate<'a> {
+  span: Span,
+  asserts: bool,
+  param_name: TsThisTypeOrIdent<'a>,
+  type_ann: Option<&'a TsTypeAnn<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypePredicate<'a>> for SerializableTsTypePredicate<'a> {
+  fn from(orig: TsTypePredicate<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      asserts: orig.asserts().clone(),
+      param_name: orig.param_name,
+      type_ann: orig.type_ann,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeQuery", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeQuery<'a> {
+  span: Span,
+  expr_name: TsTypeQueryExpr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeQuery<'a>> for SerializableTsTypeQuery<'a> {
+  fn from(orig: TsTypeQuery<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      expr_name: orig.expr_name,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsTypeRef", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsTypeRef<'a> {
+  span: Span,
+  type_name: TsEntityName<'a>,
+  type_params: Option<&'a TsTypeParamInstantiation<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsTypeRef<'a>> for SerializableTsTypeRef<'a> {
+  fn from(orig: TsTypeRef<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      type_name: orig.type_name,
+      type_params: orig.type_params,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "TsUnionType", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableTsUnionType<'a> {
+  span: Span,
+  types: Vec<TsType<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<TsUnionType<'a>> for SerializableTsUnionType<'a> {
+  fn from(orig: TsUnionType<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      types: orig.types,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "UnaryExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableUnaryExpr<'a> {
+  span: Span,
+  op: UnaryOp,
+  arg: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<UnaryExpr<'a>> for SerializableUnaryExpr<'a> {
+  fn from(orig: UnaryExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      op: orig.op().clone(),
+      arg: orig.arg,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "UpdateExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableUpdateExpr<'a> {
+  span: Span,
+  op: UpdateOp,
+  prefix: bool,
+  arg: Expr<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<UpdateExpr<'a>> for SerializableUpdateExpr<'a> {
+  fn from(orig: UpdateExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      op: orig.op().clone(),
+      prefix: orig.prefix().clone(),
+      arg: orig.arg,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "VarDecl", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableVarDecl<'a> {
+  span: Span,
+  kind: VarDeclKind,
+  declare: bool,
+  decls: Vec<&'a VarDeclarator<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<VarDecl<'a>> for SerializableVarDecl<'a> {
+  fn from(orig: VarDecl<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      kind: orig.kind().clone(),
+      declare: orig.declare().clone(),
+      decls: orig.decls,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "VarDeclarator", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableVarDeclarator<'a> {
+  span: Span,
+  definite: bool,
+  name: Pat<'a>,
+  init: Option<Expr<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<VarDeclarator<'a>> for SerializableVarDeclarator<'a> {
+  fn from(orig: VarDeclarator<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      definite: orig.definite().clone(),
+      name: orig.name,
+      init: orig.init,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "WhileStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableWhileStmt<'a> {
+  span: Span,
+  test: Expr<'a>,
+  body: Stmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<WhileStmt<'a>> for SerializableWhileStmt<'a> {
+  fn from(orig: WhileStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      test: orig.test,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "WithStmt", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableWithStmt<'a> {
+  span: Span,
+  obj: Expr<'a>,
+  body: Stmt<'a>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<WithStmt<'a>> for SerializableWithStmt<'a> {
+  fn from(orig: WithStmt<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      obj: orig.obj,
+      body: orig.body,
+      _phantom: PhantomData,
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename = "YieldExpr", rename_all = "camelCase", tag = "nodeKind")]
+pub struct SerializableYieldExpr<'a> {
+  span: Span,
+  delegate: bool,
+  arg: Option<Expr<'a>>,
+
+  #[doc(hidden)]
+  #[serde(skip)]
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> From<YieldExpr<'a>> for SerializableYieldExpr<'a> {
+  fn from(orig: YieldExpr<'a>) -> Self {
+    Self {
+      span: orig.span(),
+      delegate: orig.delegate().clone(),
+      arg: orig.arg,
+      _phantom: PhantomData,
+    }
+  }
+}

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -1,6 +1,8 @@
 mod comments;
 #[allow(invalid_value)]
 mod generated;
+#[cfg(feature = "serialize")]
+mod generated_serialize;
 mod tokens;
 mod types;
 

--- a/rs-lib/src/types.rs
+++ b/rs-lib/src/types.rs
@@ -1,9 +1,11 @@
 use crate::comments::*;
 use crate::generated::*;
 use crate::tokens::*;
-use serde::Serialize;
 use swc_common::{comments::SingleThreadedComments, BytePos, Span, Spanned};
 use swc_ecmascript::parser::token::TokenAndSpan;
+
+#[cfg(feature = "serialize")]
+use serde::Serialize;
 
 pub enum NodeOrToken<'a> {
   Node(Node<'a>),
@@ -80,8 +82,9 @@ implement_root_node!(Script<'a>);
 implement_root_node!(&Script<'a>);
 
 /// A Module or Script node.
-#[derive(Clone, Copy, Serialize)]
-#[serde(untagged)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum Program<'a> {
   Module(&'a Module<'a>),
   Script(&'a Script<'a>),

--- a/rs-lib/src/types.rs
+++ b/rs-lib/src/types.rs
@@ -1,6 +1,7 @@
 use crate::comments::*;
 use crate::generated::*;
 use crate::tokens::*;
+use serde::Serialize;
 use swc_common::{comments::SingleThreadedComments, BytePos, Span, Spanned};
 use swc_ecmascript::parser::token::TokenAndSpan;
 
@@ -79,7 +80,8 @@ implement_root_node!(Script<'a>);
 implement_root_node!(&Script<'a>);
 
 /// A Module or Script node.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize)]
+#[serde(untagged)]
 pub enum Program<'a> {
   Module(&'a Module<'a>),
   Script(&'a Script<'a>),

--- a/rs-lib/tests/expected/serialize_ts_function.json
+++ b/rs-lib/tests/expected/serialize_ts_function.json
@@ -5,6 +5,7 @@
     "end": 67,
     "ctxt": 0
   },
+  "shebang": null,
   "body": [
     {
       "nodeKind": "FnDecl",
@@ -13,6 +14,7 @@
         "end": 67,
         "ctxt": 0
       },
+      "declare": false,
       "ident": {
         "nodeKind": "Ident",
         "span": {
@@ -30,6 +32,8 @@
           "end": 67,
           "ctxt": 0
         },
+        "isGenerator": false,
+        "isAsync": false,
         "params": [
           {
             "nodeKind": "Param",
@@ -46,6 +50,7 @@
                 "end": 33,
                 "ctxt": 0
               },
+              "optional": false,
               "props": [
                 {
                   "nodeKind": "AssignPatProp",
@@ -89,6 +94,9 @@
                         "end": 31,
                         "ctxt": 0
                       },
+                      "readonly": false,
+                      "computed": false,
+                      "optional": false,
                       "key": {
                         "nodeKind": "Ident",
                         "span": {
@@ -118,15 +126,11 @@
                           "kind": "number"
                         }
                       },
-                      "typeParams": null,
-                      "readonly": false,
-                      "computed": false,
-                      "optional": false
+                      "typeParams": null
                     }
                   ]
                 }
-              },
-              "optional": false
+              }
             }
           }
         ],
@@ -153,6 +157,7 @@
                   "end": 64,
                   "ctxt": 0
                 },
+                "op": "===",
                 "left": {
                   "nodeKind": "BinExpr",
                   "span": {
@@ -160,6 +165,7 @@
                     "end": 58,
                     "ctxt": 0
                   },
+                  "op": "%",
                   "left": {
                     "nodeKind": "Ident",
                     "span": {
@@ -178,8 +184,7 @@
                       "ctxt": 0
                     },
                     "value": 2.0
-                  },
-                  "op": "%"
+                  }
                 },
                 "right": {
                   "nodeKind": "Number",
@@ -189,8 +194,7 @@
                     "ctxt": 0
                   },
                   "value": 0.0
-                },
-                "op": "==="
+                }
               }
             }
           ]
@@ -212,12 +216,8 @@
             },
             "kind": "boolean"
           }
-        },
-        "isGenerator": false,
-        "isAsync": false
-      },
-      "declare": false
+        }
+      }
     }
-  ],
-  "shebang": null
+  ]
 }

--- a/rs-lib/tests/expected/serialize_ts_function.json
+++ b/rs-lib/tests/expected/serialize_ts_function.json
@@ -1,0 +1,223 @@
+{
+  "nodeKind": "Module",
+  "span": {
+    "start": 0,
+    "end": 67,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "nodeKind": "FnDecl",
+      "span": {
+        "start": 0,
+        "end": 67,
+        "ctxt": 0
+      },
+      "ident": {
+        "nodeKind": "Ident",
+        "span": {
+          "start": 9,
+          "end": 12,
+          "ctxt": 0
+        },
+        "sym": "foo",
+        "optional": false
+      },
+      "function": {
+        "nodeKind": "Function",
+        "span": {
+          "start": 0,
+          "end": 67,
+          "ctxt": 0
+        },
+        "params": [
+          {
+            "nodeKind": "Param",
+            "span": {
+              "start": 13,
+              "end": 33,
+              "ctxt": 0
+            },
+            "decorators": [],
+            "pat": {
+              "nodeKind": "ObjectPat",
+              "span": {
+                "start": 13,
+                "end": 33,
+                "ctxt": 0
+              },
+              "props": [
+                {
+                  "nodeKind": "AssignPatProp",
+                  "span": {
+                    "start": 15,
+                    "end": 16,
+                    "ctxt": 0
+                  },
+                  "key": {
+                    "nodeKind": "Ident",
+                    "span": {
+                      "start": 15,
+                      "end": 16,
+                      "ctxt": 0
+                    },
+                    "sym": "a",
+                    "optional": false
+                  },
+                  "value": null
+                }
+              ],
+              "typeAnn": {
+                "nodeKind": "TsTypeAnn",
+                "span": {
+                  "start": 18,
+                  "end": 33,
+                  "ctxt": 0
+                },
+                "typeAnn": {
+                  "nodeKind": "TsTypeLit",
+                  "span": {
+                    "start": 20,
+                    "end": 33,
+                    "ctxt": 0
+                  },
+                  "members": [
+                    {
+                      "nodeKind": "TsPropertySignature",
+                      "span": {
+                        "start": 22,
+                        "end": 31,
+                        "ctxt": 0
+                      },
+                      "key": {
+                        "nodeKind": "Ident",
+                        "span": {
+                          "start": 22,
+                          "end": 23,
+                          "ctxt": 0
+                        },
+                        "sym": "a",
+                        "optional": false
+                      },
+                      "init": null,
+                      "params": [],
+                      "typeAnn": {
+                        "nodeKind": "TsTypeAnn",
+                        "span": {
+                          "start": 23,
+                          "end": 31,
+                          "ctxt": 0
+                        },
+                        "typeAnn": {
+                          "nodeKind": "TsKeywordType",
+                          "span": {
+                            "start": 25,
+                            "end": 31,
+                            "ctxt": 0
+                          },
+                          "kind": "number"
+                        }
+                      },
+                      "typeParams": null,
+                      "readonly": false,
+                      "computed": false,
+                      "optional": false
+                    }
+                  ]
+                }
+              },
+              "optional": false
+            }
+          }
+        ],
+        "decorators": [],
+        "body": {
+          "nodeKind": "BlockStmt",
+          "span": {
+            "start": 44,
+            "end": 67,
+            "ctxt": 0
+          },
+          "stmts": [
+            {
+              "nodeKind": "ReturnStmt",
+              "span": {
+                "start": 46,
+                "end": 65,
+                "ctxt": 0
+              },
+              "arg": {
+                "nodeKind": "BinExpr",
+                "span": {
+                  "start": 53,
+                  "end": 64,
+                  "ctxt": 0
+                },
+                "left": {
+                  "nodeKind": "BinExpr",
+                  "span": {
+                    "start": 53,
+                    "end": 58,
+                    "ctxt": 0
+                  },
+                  "left": {
+                    "nodeKind": "Ident",
+                    "span": {
+                      "start": 53,
+                      "end": 54,
+                      "ctxt": 0
+                    },
+                    "sym": "a",
+                    "optional": false
+                  },
+                  "right": {
+                    "nodeKind": "Number",
+                    "span": {
+                      "start": 57,
+                      "end": 58,
+                      "ctxt": 0
+                    },
+                    "value": 2.0
+                  },
+                  "op": "%"
+                },
+                "right": {
+                  "nodeKind": "Number",
+                  "span": {
+                    "start": 63,
+                    "end": 64,
+                    "ctxt": 0
+                  },
+                  "value": 0.0
+                },
+                "op": "==="
+              }
+            }
+          ]
+        },
+        "typeParams": null,
+        "returnType": {
+          "nodeKind": "TsTypeAnn",
+          "span": {
+            "start": 34,
+            "end": 43,
+            "ctxt": 0
+          },
+          "typeAnn": {
+            "nodeKind": "TsKeywordType",
+            "span": {
+              "start": 36,
+              "end": 43,
+              "ctxt": 0
+            },
+            "kind": "boolean"
+          }
+        },
+        "isGenerator": false,
+        "isAsync": false
+      },
+      "declare": false
+    }
+  ],
+  "shebang": null
+}

--- a/rs-lib/tests/expected/serialize_var_decl.json
+++ b/rs-lib/tests/expected/serialize_var_decl.json
@@ -5,6 +5,7 @@
     "end": 13,
     "ctxt": 0
   },
+  "shebang": null,
   "body": [
     {
       "nodeKind": "VarDecl",
@@ -13,6 +14,8 @@
         "end": 13,
         "ctxt": 0
       },
+      "kind": "let",
+      "declare": false,
       "decls": [
         {
           "nodeKind": "VarDeclarator",
@@ -21,6 +24,7 @@
             "end": 12,
             "ctxt": 0
           },
+          "definite": false,
           "name": {
             "nodeKind": "BindingIdent",
             "span": {
@@ -48,13 +52,9 @@
               "ctxt": 0
             },
             "value": 42.0
-          },
-          "definite": false
+          }
         }
-      ],
-      "kind": "let",
-      "declare": false
+      ]
     }
-  ],
-  "shebang": null
+  ]
 }

--- a/rs-lib/tests/expected/serialize_var_decl.json
+++ b/rs-lib/tests/expected/serialize_var_decl.json
@@ -1,0 +1,60 @@
+{
+  "nodeKind": "Module",
+  "span": {
+    "start": 0,
+    "end": 13,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "nodeKind": "VarDecl",
+      "span": {
+        "start": 0,
+        "end": 13,
+        "ctxt": 0
+      },
+      "decls": [
+        {
+          "nodeKind": "VarDeclarator",
+          "span": {
+            "start": 4,
+            "end": 12,
+            "ctxt": 0
+          },
+          "name": {
+            "nodeKind": "BindingIdent",
+            "span": {
+              "start": 4,
+              "end": 7,
+              "ctxt": 0
+            },
+            "id": {
+              "nodeKind": "Ident",
+              "span": {
+                "start": 4,
+                "end": 7,
+                "ctxt": 0
+              },
+              "sym": "foo",
+              "optional": false
+            },
+            "typeAnn": null
+          },
+          "init": {
+            "nodeKind": "Number",
+            "span": {
+              "start": 10,
+              "end": 12,
+              "ctxt": 0
+            },
+            "value": 42.0
+          },
+          "definite": false
+        }
+      ],
+      "kind": "let",
+      "declare": false
+    }
+  ],
+  "shebang": null
+}

--- a/rs-lib/tests/helpers.rs
+++ b/rs-lib/tests/helpers.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path};
+use std::path::Path;
 use swc_common::{
   comments::SingleThreadedComments,
   errors::{DiagnosticBuilder, Emitter, Handler},
@@ -153,13 +153,13 @@ pub fn get_swc_script(
   .unwrap();
 }
 
+#[cfg(feature = "serialize")]
 pub fn run_serialize_test(file_text: &str, expected_json_path: impl AsRef<Path>) {
   let file_path = Path::new("test.ts");
   run_test_with_module(&file_path, file_text, |module| {
     let result = serde_json::to_string_pretty(&module).unwrap();
-    eprintln!("{}", &result);
-    let expected = fs::read_to_string(expected_json_path.as_ref()).unwrap();
-    assert_eq!(result, expected.trim());
+    let expected = std::fs::read_to_string(expected_json_path.as_ref()).unwrap();
+    pretty_assertions::assert_eq!(result, expected.trim());
   });
 }
 

--- a/rs-lib/tests/helpers.rs
+++ b/rs-lib/tests/helpers.rs
@@ -1,180 +1,190 @@
-use std::path::Path;
+use std::{fs, path::Path};
 use swc_common::{
-    comments::SingleThreadedComments,
-    errors::{DiagnosticBuilder, Emitter, Handler},
-    BytePos, FileName, SourceFile,
+  comments::SingleThreadedComments,
+  errors::{DiagnosticBuilder, Emitter, Handler},
+  BytePos, FileName, SourceFile,
 };
 use swc_ecmascript::ast::{Module, Script};
 use swc_ecmascript::parser::{
-    lexer::Lexer, token::TokenAndSpan, Capturing, JscTarget, Parser, StringInput, Syntax,
+  lexer::Lexer, token::TokenAndSpan, Capturing, JscTarget, Parser, StringInput, Syntax,
 };
 
 pub fn run_test(file_text: &str, run_test: impl Fn(dprint_swc_ecma_ast_view::Program)) {
-    let file_path = Path::new("test.ts");
-    run_test_with_module(file_path, file_text, |module| {
-        run_test(dprint_swc_ecma_ast_view::Program::Module(module))
-    });
-    run_test_with_script(file_path, file_text, |script| {
-        run_test(dprint_swc_ecma_ast_view::Program::Script(script))
-    });
+  let file_path = Path::new("test.ts");
+  run_test_with_module(file_path, file_text, |module| {
+    run_test(dprint_swc_ecma_ast_view::Program::Module(module))
+  });
+  run_test_with_script(file_path, file_text, |script| {
+    run_test(dprint_swc_ecma_ast_view::Program::Script(script))
+  });
 }
 
 pub fn run_test_with_module(
-    file_path: &Path,
-    file_text: &str,
-    run_test: impl Fn(&dprint_swc_ecma_ast_view::Module),
+  file_path: &Path,
+  file_text: &str,
+  run_test: impl Fn(&dprint_swc_ecma_ast_view::Module),
 ) {
-    let (module, tokens, source_file, comments) = get_swc_module(file_path, file_text);
-    let info = dprint_swc_ecma_ast_view::ModuleInfo {
-        module: &module,
-        source_file: Some(&source_file),
-        tokens: Some(&tokens),
-        comments: Some(&comments),
-    };
-    dprint_swc_ecma_ast_view::with_ast_view_for_module(info, |module| {
-        run_test(module);
-    });
+  let (module, tokens, source_file, comments) = get_swc_module(file_path, file_text);
+  let info = dprint_swc_ecma_ast_view::ModuleInfo {
+    module: &module,
+    source_file: Some(&source_file),
+    tokens: Some(&tokens),
+    comments: Some(&comments),
+  };
+  dprint_swc_ecma_ast_view::with_ast_view_for_module(info, |module| {
+    run_test(module);
+  });
 }
 
 pub fn run_test_with_script(
-    file_path: &Path,
-    file_text: &str,
-    run_test: impl Fn(&dprint_swc_ecma_ast_view::Script),
+  file_path: &Path,
+  file_text: &str,
+  run_test: impl Fn(&dprint_swc_ecma_ast_view::Script),
 ) {
-    let (script, tokens, source_file, comments) = get_swc_script(file_path, file_text);
-    let info = dprint_swc_ecma_ast_view::ScriptInfo {
-        script: &script,
-        source_file: Some(&source_file),
-        tokens: Some(&tokens),
-        comments: Some(&comments),
-    };
-    dprint_swc_ecma_ast_view::with_ast_view_for_script(info, |script| {
-        run_test(script);
-    });
+  let (script, tokens, source_file, comments) = get_swc_script(file_path, file_text);
+  let info = dprint_swc_ecma_ast_view::ScriptInfo {
+    script: &script,
+    source_file: Some(&source_file),
+    tokens: Some(&tokens),
+    comments: Some(&comments),
+  };
+  dprint_swc_ecma_ast_view::with_ast_view_for_script(info, |script| {
+    run_test(script);
+  });
 }
 
 pub fn get_swc_module(
-    file_path: &Path,
-    file_text: &str,
+  file_path: &Path,
+  file_text: &str,
 ) -> (
-    Module,
-    Vec<TokenAndSpan>,
-    SourceFile,
-    SingleThreadedComments,
+  Module,
+  Vec<TokenAndSpan>,
+  SourceFile,
+  SingleThreadedComments,
 ) {
-    // lifted from dprint-plugin-typescript
-    let handler = Handler::with_emitter(false, false, Box::new(EmptyEmitter {}));
-    let source_file = SourceFile::new(
-        FileName::Custom(file_path.to_string_lossy().into()),
-        false,
-        FileName::Custom(file_path.to_string_lossy().into()),
-        file_text.into(),
-        BytePos(0),
+  // lifted from dprint-plugin-typescript
+  let handler = Handler::with_emitter(false, false, Box::new(EmptyEmitter {}));
+  let source_file = SourceFile::new(
+    FileName::Custom(file_path.to_string_lossy().into()),
+    false,
+    FileName::Custom(file_path.to_string_lossy().into()),
+    file_text.into(),
+    BytePos(0),
+  );
+
+  let comments: SingleThreadedComments = Default::default();
+  return {
+    let mut ts_config: swc_ecmascript::parser::TsConfig = Default::default();
+    ts_config.tsx = should_parse_as_jsx(file_path);
+    ts_config.dynamic_import = true;
+    ts_config.decorators = true;
+    let lexer = Lexer::new(
+      Syntax::Typescript(ts_config),
+      JscTarget::Es2019,
+      StringInput::from(&source_file),
+      Some(&comments),
     );
+    let lexer = Capturing::new(lexer);
+    let mut parser = Parser::new_from(lexer);
+    let parse_module_result = parser.parse_module();
+    let tokens = parser.input().take();
 
-    let comments: SingleThreadedComments = Default::default();
-    return {
-        let mut ts_config: swc_ecmascript::parser::TsConfig = Default::default();
-        ts_config.tsx = should_parse_as_jsx(file_path);
-        ts_config.dynamic_import = true;
-        ts_config.decorators = true;
-        let lexer = Lexer::new(
-            Syntax::Typescript(ts_config),
-            JscTarget::Es2019,
-            StringInput::from(&source_file),
-            Some(&comments),
-        );
-        let lexer = Capturing::new(lexer);
-        let mut parser = Parser::new_from(lexer);
-        let parse_module_result = parser.parse_module();
-        let tokens = parser.input().take();
-
-        match parse_module_result {
-            Err(error) => {
-                // mark the diagnostic as being handled (otherwise it will panic in its drop)
-                let mut diagnostic = error.into_diagnostic(&handler);
-                diagnostic.cancel();
-                // return the formatted diagnostic string
-                Err(diagnostic.message())
-            }
-            Ok(module) => Ok((module, tokens, source_file, comments)),
-        }
+    match parse_module_result {
+      Err(error) => {
+        // mark the diagnostic as being handled (otherwise it will panic in its drop)
+        let mut diagnostic = error.into_diagnostic(&handler);
+        diagnostic.cancel();
+        // return the formatted diagnostic string
+        Err(diagnostic.message())
+      }
+      Ok(module) => Ok((module, tokens, source_file, comments)),
     }
-    .unwrap();
+  }
+  .unwrap();
 }
 
 pub fn get_swc_script(
-    file_path: &Path,
-    file_text: &str,
+  file_path: &Path,
+  file_text: &str,
 ) -> (
-    Script,
-    Vec<TokenAndSpan>,
-    SourceFile,
-    SingleThreadedComments,
+  Script,
+  Vec<TokenAndSpan>,
+  SourceFile,
+  SingleThreadedComments,
 ) {
-    // lifted from dprint-plugin-typescript
-    let handler = Handler::with_emitter(false, false, Box::new(EmptyEmitter {}));
-    let source_file = SourceFile::new(
-        FileName::Custom(file_path.to_string_lossy().into()),
-        false,
-        FileName::Custom(file_path.to_string_lossy().into()),
-        file_text.into(),
-        BytePos(0),
+  // lifted from dprint-plugin-typescript
+  let handler = Handler::with_emitter(false, false, Box::new(EmptyEmitter {}));
+  let source_file = SourceFile::new(
+    FileName::Custom(file_path.to_string_lossy().into()),
+    false,
+    FileName::Custom(file_path.to_string_lossy().into()),
+    file_text.into(),
+    BytePos(0),
+  );
+
+  let comments: SingleThreadedComments = Default::default();
+  return {
+    let mut ts_config: swc_ecmascript::parser::TsConfig = Default::default();
+    ts_config.tsx = should_parse_as_jsx(file_path);
+    ts_config.dynamic_import = true;
+    ts_config.decorators = true;
+    let lexer = Lexer::new(
+      Syntax::Typescript(ts_config),
+      JscTarget::Es2019,
+      StringInput::from(&source_file),
+      Some(&comments),
     );
+    let lexer = Capturing::new(lexer);
+    let mut parser = Parser::new_from(lexer);
+    let parse_script_result = parser.parse_script();
+    let tokens = parser.input().take();
 
-    let comments: SingleThreadedComments = Default::default();
-    return {
-        let mut ts_config: swc_ecmascript::parser::TsConfig = Default::default();
-        ts_config.tsx = should_parse_as_jsx(file_path);
-        ts_config.dynamic_import = true;
-        ts_config.decorators = true;
-        let lexer = Lexer::new(
-            Syntax::Typescript(ts_config),
-            JscTarget::Es2019,
-            StringInput::from(&source_file),
-            Some(&comments),
-        );
-        let lexer = Capturing::new(lexer);
-        let mut parser = Parser::new_from(lexer);
-        let parse_script_result = parser.parse_script();
-        let tokens = parser.input().take();
-
-        match parse_script_result {
-            Err(error) => {
-                // mark the diagnostic as being handled (otherwise it will panic in its drop)
-                let mut diagnostic = error.into_diagnostic(&handler);
-                diagnostic.cancel();
-                // return the formatted diagnostic string
-                Err(diagnostic.message())
-            }
-            Ok(script) => Ok((script, tokens, source_file, comments)),
-        }
+    match parse_script_result {
+      Err(error) => {
+        // mark the diagnostic as being handled (otherwise it will panic in its drop)
+        let mut diagnostic = error.into_diagnostic(&handler);
+        diagnostic.cancel();
+        // return the formatted diagnostic string
+        Err(diagnostic.message())
+      }
+      Ok(script) => Ok((script, tokens, source_file, comments)),
     }
-    .unwrap();
+  }
+  .unwrap();
+}
+
+pub fn run_serialize_test(file_text: &str, expected_json_path: impl AsRef<Path>) {
+  let file_path = Path::new("test.ts");
+  run_test_with_module(&file_path, file_text, |module| {
+    let result = serde_json::to_string_pretty(&module).unwrap();
+    eprintln!("{}", &result);
+    let expected = fs::read_to_string(expected_json_path.as_ref()).unwrap();
+    assert_eq!(result, expected.trim());
+  });
 }
 
 fn should_parse_as_jsx(file_path: &Path) -> bool {
-    if let Some(extension) = get_lowercase_extension(file_path) {
-        return extension == "tsx" || extension == "jsx" || extension == "js" || extension == "mjs";
-    }
-    return true;
+  if let Some(extension) = get_lowercase_extension(file_path) {
+    return extension == "tsx" || extension == "jsx" || extension == "js" || extension == "mjs";
+  }
+  return true;
 }
 
 fn get_lowercase_extension(file_path: &Path) -> Option<String> {
-    file_path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|f| f.to_lowercase())
+  file_path
+    .extension()
+    .and_then(|e| e.to_str())
+    .map(|f| f.to_lowercase())
 }
 
 pub struct EmptyEmitter {}
 
 impl Emitter for EmptyEmitter {
-    fn emit(&mut self, _: &DiagnosticBuilder<'_>) {
-        // for now, we don't care about diagnostics so do nothing
-    }
+  fn emit(&mut self, _: &DiagnosticBuilder<'_>) {
+    // for now, we don't care about diagnostics so do nothing
+  }
 
-    fn should_show_explain(&self) -> bool {
-        false
-    }
+  fn should_show_explain(&self) -> bool {
+    false
+  }
 }

--- a/rs-lib/tests/test.rs
+++ b/rs-lib/tests/test.rs
@@ -15,6 +15,7 @@ fn it_should_get_children() {
   });
 }
 
+#[cfg(feature = "serialize")]
 #[test]
 fn it_shoule_be_serialized_to_json() {
   let tests = [

--- a/rs-lib/tests/test.rs
+++ b/rs-lib/tests/test.rs
@@ -14,3 +14,18 @@ fn it_should_get_children() {
     assert_eq!(children[1].text(), "b: number;");
   });
 }
+
+#[test]
+fn it_shoule_be_serialized_to_json() {
+  let tests = [
+    ("let foo = 42;", "./tests/expected/serialize_var_decl.json"),
+    (
+      "function foo({ a }: { a: number }): boolean { return a % 2 === 0; }",
+      "./tests/expected/serialize_ts_function.json",
+    ),
+  ];
+
+  for (code, expected_path) in tests.iter() {
+    run_serialize_test(code, expected_path);
+  }
+}


### PR DESCRIPTION
This patch implements `Serialize` trait for each `Node`. This will be super useful for making deno_lint's plugin system I'm working on more practical.

The difference may be a bit hard to follow, but how it works can be seen in test cases. See `rs-lib/tests/test.rs` and ` rs-lib/tests/expected/*.json`. 

For now I don't need to have `Deserialize` trait implemented, so I didn't do that.