### PR TITLE
feat: Add `all_comments` method to `CommentContainer`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,13 @@ jobs:
       run: |
         . $BVM_INSTALL_DIR/bin/bvm-init
         cargo install cargo-clone
-        rustup toolchain install nightly-2021-04-07
+        rustup toolchain install $NIGHTLY_VERSION
         chmod +x ./scripts/generate.sh
         ./scripts/generate.sh
         echo Checking for git changes...
         git diff --no-ext-diff --exit-code
+      env:
+        NIGHTLY_VERSION: nightly-2021-04-07
 
     - name: Build debug
       if: matrix.config.kind == 'test_debug'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         . $BVM_INSTALL_DIR/bin/bvm-init
         cargo install cargo-clone
-        rustup toolchain install nightly
+        rustup toolchain install nightly-2021-04-07
         chmod +x ./scripts/generate.sh
         ./scripts/generate.sh
         echo Checking for git changes...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,11 @@ jobs:
       run: |
         . $BVM_INSTALL_DIR/bin/bvm-init
         cargo install cargo-clone
-        rustup toolchain install $NIGHTLY_VERSION
+        rustup toolchain install nightly
         chmod +x ./scripts/generate.sh
         ./scripts/generate.sh
         echo Checking for git changes...
         git diff --no-ext-diff --exit-code
-      env:
-        NIGHTLY_VERSION: nightly-2021-04-07
 
     - name: Build debug
       if: matrix.config.kind == 'test_debug'

--- a/rs-lib/src/comments.rs
+++ b/rs-lib/src/comments.rs
@@ -27,6 +27,14 @@ impl<'a> CommentContainer<'a> {
     }
   }
 
+  pub fn all_comments(&'a self) -> CommentsIterator<'a> {
+    let approx_cap = self.leading.len() + self.trailing.len();
+    let mut v = Vec::with_capacity(approx_cap);
+    v.extend(self.leading.values());
+    v.extend(self.trailing.values());
+    CommentsIterator::new(v)
+  }
+
   pub fn leading_comments(&'a self, lo: BytePos) -> CommentsIterator<'a> {
     let previous_token_hi = self.tokens.get_previous_token_hi(lo).unwrap_or(BytePos(0));
     let trailing = self.get_trailing(previous_token_hi);

--- a/rs-lib/src/comments.rs
+++ b/rs-lib/src/comments.rs
@@ -27,14 +27,14 @@ impl<'a> CommentContainer<'a> {
     }
   }
 
-  pub fn leading_comments(&self, lo: BytePos) -> CommentsIterator<'a> {
+  pub fn leading_comments(&'a self, lo: BytePos) -> CommentsIterator<'a> {
     let previous_token_hi = self.tokens.get_previous_token_hi(lo).unwrap_or(BytePos(0));
     let trailing = self.get_trailing(previous_token_hi);
     let leading = self.get_leading(lo);
     combine_comment_vecs(trailing, leading)
   }
 
-  pub fn trailing_comments(&self, hi: BytePos) -> CommentsIterator<'a> {
+  pub fn trailing_comments(&'a self, hi: BytePos) -> CommentsIterator<'a> {
     let next_token_lo = self
       .tokens
       .get_next_token_lo(hi)
@@ -44,20 +44,12 @@ impl<'a> CommentContainer<'a> {
     combine_comment_vecs(trailing, leading)
   }
 
-  fn get_leading(&self, lo: BytePos) -> Option<&'a Vec<Comment>> {
-    let leading = self.leading.get(&lo);
-    // todo: how to not do this?
-    let leading =
-      unsafe { std::mem::transmute::<Option<&Vec<Comment>>, Option<&'a Vec<Comment>>>(leading) };
-    leading
+  fn get_leading(&'a self, lo: BytePos) -> Option<&'a Vec<Comment>> {
+    self.leading.get(&lo)
   }
 
-  fn get_trailing(&self, hi: BytePos) -> Option<&'a Vec<Comment>> {
-    let trailing = self.trailing.get(&hi);
-    // todo: how to not do this?
-    let trailing =
-      unsafe { std::mem::transmute::<Option<&Vec<Comment>>, Option<&'a Vec<Comment>>>(trailing) };
-    trailing
+  fn get_trailing(&'a self, hi: BytePos) -> Option<&'a Vec<Comment>> {
+    self.trailing.get(&hi)
   }
 }
 

--- a/rs-lib/tests/test.rs
+++ b/rs-lib/tests/test.rs
@@ -15,6 +15,33 @@ fn it_should_get_children() {
   });
 }
 
+#[test]
+fn it_should_get_all_comments() {
+  run_test(
+    r#"
+/// <reference path="foo" />
+const a = 42;
+
+/* 
+ * block comment
+ */
+let b = true;
+
+// line comment
+let c = "";
+
+function foo(name: /* inline comment */ string) {
+  console.log(`hello, ${name}`); // greeting!
+}
+
+// trailing comment
+"#,
+    |program| {
+      assert_eq!(program.comments().unwrap().all_comments().count(), 6);
+    },
+  );
+}
+
 #[cfg(feature = "serialize")]
 #[test]
 fn it_should_be_serialized_to_json() {

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -12,14 +12,14 @@ then
 
     echo "Setting up swc_ecma_ast $SWC_AST_VERSION... provide --quick to just code generate"
     rm -rf swc_ecma_ast
-    cargo clone --verbose --vers $SWC_AST_VERSION swc_ecma_ast
-    (cd swc_ecma_ast && cargo +$NIGHTLY_VERSION rustdoc --verbose -- --output-format json)
+    cargo clone --vers $SWC_AST_VERSION swc_ecma_ast
+    (cd swc_ecma_ast && cargo +nightly rustdoc -- --output-format json -Z unstable-options)
     cp swc_ecma_ast/target/doc/swc_ecma_ast.json swc_ecma_ast.json
 
     echo "Setting up swc_ecma_parser $SWC_PARSER_VERSION..."
     rm -rf swc_ecma_parser
-    cargo clone --verbose --vers $SWC_PARSER_VERSION swc_ecma_parser
-    (cd swc_ecma_parser && cargo +$NIGHTLY_VERSION rustdoc --verbose -- --output-format json)
+    cargo clone --vers $SWC_PARSER_VERSION swc_ecma_parser
+    (cd swc_ecma_parser && cargo +nightly rustdoc -- --output-format json -Z unstable-options)
     cp swc_ecma_parser/target/doc/swc_ecma_parser.json swc_ecma_parser.json
 
     echo "Generating code..."

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 # Analyze
 if [[ $* != *--quick* ]]
 then

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -13,13 +13,13 @@ then
     echo "Setting up swc_ecma_ast $SWC_AST_VERSION... provide --quick to just code generate"
     rm -rf swc_ecma_ast
     cargo clone --verbose --vers $SWC_AST_VERSION swc_ecma_ast
-    (cd swc_ecma_ast && cargo +nightly rustdoc --verbose -- --output-format json)
+    (cd swc_ecma_ast && cargo +$NIGHTLY_VERSION rustdoc --verbose -- --output-format json)
     cp swc_ecma_ast/target/doc/swc_ecma_ast.json swc_ecma_ast.json
 
     echo "Setting up swc_ecma_parser $SWC_PARSER_VERSION..."
     rm -rf swc_ecma_parser
     cargo clone --verbose --vers $SWC_PARSER_VERSION swc_ecma_parser
-    (cd swc_ecma_parser && cargo +nightly rustdoc --verbose -- --output-format json)
+    (cd swc_ecma_parser && cargo +$NIGHTLY_VERSION rustdoc --verbose -- --output-format json)
     cp swc_ecma_parser/target/doc/swc_ecma_parser.json swc_ecma_parser.json
 
     echo "Generating code..."

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -12,14 +12,14 @@ then
 
     echo "Setting up swc_ecma_ast $SWC_AST_VERSION... provide --quick to just code generate"
     rm -rf swc_ecma_ast
-    cargo clone --vers $SWC_AST_VERSION swc_ecma_ast
-    (cd swc_ecma_ast && cargo +nightly rustdoc -- --output-format json)
+    cargo clone --verbose --vers $SWC_AST_VERSION swc_ecma_ast
+    (cd swc_ecma_ast && cargo +nightly rustdoc --verbose -- --output-format json)
     cp swc_ecma_ast/target/doc/swc_ecma_ast.json swc_ecma_ast.json
 
     echo "Setting up swc_ecma_parser $SWC_PARSER_VERSION..."
     rm -rf swc_ecma_parser
-    cargo clone --vers $SWC_PARSER_VERSION swc_ecma_parser
-    (cd swc_ecma_parser && cargo +nightly rustdoc -- --output-format json)
+    cargo clone --verbose --vers $SWC_PARSER_VERSION swc_ecma_parser
+    (cd swc_ecma_parser && cargo +nightly rustdoc --verbose -- --output-format json)
     cp swc_ecma_parser/target/doc/swc_ecma_parser.json swc_ecma_parser.json
 
     echo "Generating code..."


### PR DESCRIPTION
This patch adds `all_comments` method to `CommentContainer`  to get all comments in a file, which is really useful when implementing some lint rules.

Additionally, it refactors the existing methods in `CommentContainer` to avoid using `std::mem::transmute`. This refactoring restricts the lifetime of self, but I believe it works enough.

(P.S. I also tried to avoid other `std::mem::transmute` in the generated code but haven't made it compile yet... I'll keep on thinking about it)