### PR TITLE
fix: Store tokens as `&[TokenAndSpan]` instead of `&Vec<TokenAndSpan>`

### DIFF
--- a/generation/generate/generate_serialize.ts
+++ b/generation/generate/generate_serialize.ts
@@ -118,7 +118,7 @@ export function generateSerialize(analysisResult: AnalysisResult): string {
   }
 
   function writeSerializeTokenAndSpansFunction() {
-    writer.write(`pub fn serialize_token_and_spans(&mut self, tokens: &Vec<TokenAndSpan>) -> Result<(), Error>`).block(
+    writer.write(`pub fn serialize_token_and_spans(&mut self, tokens: &[TokenAndSpan]) -> Result<(), Error>`).block(
       () => {
         writeArray(() => {
           writer.write("for (i, token_and_span) in tokens.iter().enumerate()").block(() => {

--- a/rs-lib/src/serialize/serialize.rs
+++ b/rs-lib/src/serialize/serialize.rs
@@ -32,7 +32,7 @@ pub fn serialize_token_and_spans(
   w: &mut impl Write,
   f: &mut impl JsonFormatter,
   file_text: &str,
-  token_and_spans: &Vec<TokenAndSpan>,
+  token_and_spans: &[TokenAndSpan],
 ) -> Result<(), Error> {
   let mut serializer = FileSerializer::new(w, f, file_text);
   serializer.serialize_token_and_spans(token_and_spans)

--- a/rs-lib/src/serialize/serialize_generated.rs
+++ b/rs-lib/src/serialize/serialize_generated.rs
@@ -7053,7 +7053,7 @@ impl<'a, TWrite: Write, TJsonFormatter: JsonFormatter> FileSerializer<'a, TWrite
     Ok(())
   }
 
-  pub fn serialize_token_and_spans(&mut self, tokens: &Vec<TokenAndSpan>) -> Result<(), Error> {
+  pub fn serialize_token_and_spans(&mut self, tokens: &[TokenAndSpan]) -> Result<(), Error> {
     self.f.begin_array(self.w)?;
     for (i, token_and_span) in tokens.iter().enumerate() {
       self.f.begin_array_value(self.w, i == 0)?;

--- a/rs-lib/src/tokens.rs
+++ b/rs-lib/src/tokens.rs
@@ -3,14 +3,14 @@ use swc_common::BytePos;
 use swc_ecmascript::parser::token::TokenAndSpan;
 
 pub struct TokenContainer<'a> {
-  pub tokens: &'a Vec<TokenAndSpan>,
+  pub tokens: &'a [TokenAndSpan],
   // Uses an FnvHashMap because it has faster lookups for u32 keys than the default hasher.
   lo_to_index: FnvHashMap<BytePos, usize>,
   hi_to_index: FnvHashMap<BytePos, usize>,
 }
 
 impl<'a> TokenContainer<'a> {
-  pub fn new(tokens: &'a Vec<TokenAndSpan>) -> Self {
+  pub fn new(tokens: &'a [TokenAndSpan]) -> Self {
     TokenContainer {
       tokens,
       lo_to_index: tokens

--- a/rs-lib/src/types.rs
+++ b/rs-lib/src/types.rs
@@ -536,7 +536,7 @@ pub trait CastableNode<'a> {
 pub struct ProgramInfo<'a> {
   pub program: &'a swc_ecmascript::ast::Program,
   pub source_file: Option<&'a swc_common::SourceFile>,
-  pub tokens: Option<&'a Vec<TokenAndSpan>>,
+  pub tokens: Option<&'a [TokenAndSpan]>,
   pub comments: Option<&'a SingleThreadedComments>,
 }
 
@@ -544,7 +544,7 @@ pub struct ProgramInfo<'a> {
 pub struct ModuleInfo<'a> {
   pub module: &'a swc_ecmascript::ast::Module,
   pub source_file: Option<&'a swc_common::SourceFile>,
-  pub tokens: Option<&'a Vec<TokenAndSpan>>,
+  pub tokens: Option<&'a [TokenAndSpan]>,
   pub comments: Option<&'a SingleThreadedComments>,
 }
 
@@ -552,7 +552,7 @@ pub struct ModuleInfo<'a> {
 pub struct ScriptInfo<'a> {
   pub script: &'a swc_ecmascript::ast::Script,
   pub source_file: Option<&'a swc_common::SourceFile>,
-  pub tokens: Option<&'a Vec<TokenAndSpan>>,
+  pub tokens: Option<&'a [TokenAndSpan]>,
   pub comments: Option<&'a SingleThreadedComments>,
 }
 

--- a/rs-lib/tests/helpers.rs
+++ b/rs-lib/tests/helpers.rs
@@ -1,5 +1,4 @@
-use dprint_swc_ecma_ast_view::*;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use swc_common::{
   comments::SingleThreadedComments,
   errors::{DiagnosticBuilder, Emitter, Handler},
@@ -9,6 +8,9 @@ use swc_ecmascript::ast::{Module, Script};
 use swc_ecmascript::parser::{
   lexer::Lexer, token::TokenAndSpan, Capturing, JscTarget, Parser, StringInput, Syntax,
 };
+
+#[cfg(feature = "serialize")]
+use {dprint_swc_ecma_ast_view::*, std::path::PathBuf};
 
 pub fn run_test(file_text: &str, run_test: impl Fn(dprint_swc_ecma_ast_view::Program)) {
   let file_path = Path::new("test.ts");


### PR DESCRIPTION
Currently `TokenContainer` stores tokens as `&Vec<TokenAndSpan>`. It works fine but clippy complains:

```
error: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices
  --> src/tokens.rs:13:22
   |
13 |   pub fn new(tokens: &'a Vec<TokenAndSpan>) -> Self {
   |                      ^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[TokenAndSpan]`
   |
   = note: `-D clippy::ptr-arg` implied by `-D clippy::all`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
```

(The same error happens in [deno_lint's PR](https://github.com/denoland/deno_lint/pull/677/checks?check_run_id=2482745329) as well)
In fact, it looks like converting the type from `&Vec<TokenAndSpan>` to `&[TokenAndSpan]` should work enough, so in this PR I've done it.