### PR TITLE
feat: upgrade swc

### DIFF
--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -11,8 +11,8 @@ bumpalo = "3.8.0"
 num-bigint = "0.2"
 rustc-hash = "1.1.0"
 swc_atoms = "0.2.9"
-swc_common = "0.17.2"
-swc_ecmascript = { version = "0.111.10", features = ["parser"] }
+swc_common = "0.17.5"
+swc_ecmascript = { version = "0.114.2", features = ["parser"] }
 text_lines = "0.4.1"
 
 [dev-dependencies]


### PR DESCRIPTION
It seems like the latest version of swc solves https://github.com/denoland/deno_lint/issues/1011, which I can confirm by comparing the AST output from different versions of swc in [the swc playground](https://swc.rs/playground). So it would be nice to upgrade it.
Relavant PR is https://github.com/swc-project/swc/pull/3449